### PR TITLE
Feature/with tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,6 @@
 .vs*
 x64*
 
-*.txt
 *.log
 *.tlog
 *.TMP

--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,7 @@
 *.app
 
 #others
-
+*.*pre1
 *.rej
 *.stash
 *.rc
@@ -50,6 +50,7 @@
 *.exp
 *.ilk
 *.pdb
+*.autosave
 
 # Visual Studio files
 .vs*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ set (SOURCES
     src/AKAZE2/fed.cpp
     src/AKAZE2/nldiffusion_functions.cpp
     src/SolARSVDTriangulationOpencv.cpp
-	src/SolAROpticalFlowPytLKOpencv.cpp
+	src/SolAROpticalFlowPyrLKOpencv.cpp
     src/SolARFundamentalMatrixEstimationOpencv.cpp
     src/SolARSVDFundamentalMatrixDecomposerOpencv.cpp
     src/SolARImageFilterBinaryOpencv.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ project("SolARModuleOpenCV")
 set (SOURCES 
     src/SolARModuleOpencv.cpp
     src/SolARKeypointDetectorOpencv.cpp
+	src/SolARKeypointDetectorRegionOpencv.cpp
     src/SolARImageLoaderOpencv.cpp
     src/SolARImageConvertorOpencv.cpp
 	src/SolARImageConvertorUnity.cpp
@@ -16,6 +17,8 @@ set (SOURCES
     src/SolARMarker2DNaturalImageOpencv.cpp
     src/SolARContoursExtractorOpencv.cpp
     src/SolARPerspectiveControllerOpencv.cpp
+    src/SolARProjectOpencv.cpp
+    src/SolARUnprojectPlanarPointsOpencv.cpp
     src/SolARMarker2DSquaredBinaryOpencv.cpp
     src/SolARContoursFilterBinaryMarkerOpencv.cpp
     src/SolARDescriptorsExtractorSBPatternOpencv.cpp
@@ -62,12 +65,15 @@ set (HEADERS
     interfaces/SolARImageLoaderOpencv.h
     interfaces/SolARImageViewerOpencv.h
     interfaces/SolARKeypointDetectorOpencv.h
+    interfaces/SolARKeypointDetectorRegionOpencv.h
     interfaces/SolAROpenCVHelper.h
     interfaces/SolAROpencvAPI.h
     interfaces/SolARCameraCalibrationOpencv.h
     interfaces/SolARMarker2DNaturalImageOpencv.h
     interfaces/SolARContoursExtractorOpencv.h
     interfaces/SolARPerspectiveControllerOpencv.h
+    interfaces/SolARProjectOpencv.h
+    interfaces/SolARUnprojectPlanarPointsOpencv.h
     interfaces/SolARMarker2DSquaredBinaryOpencv.h
     interfaces/SolARContoursFilterBinaryMarkerOpencv.h
     interfaces/SolARDescriptorsExtractorSBPatternOpencv.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ set (SOURCES
     src/SolARGeometricMatchesFilterOpencv.cpp
     src/SolAR2DOverlayOpencv.cpp
     src/SolARHomographyEstimationOpencv.cpp
+	src/SolARPoseEstimationPlanarPointsOpencv.cpp
     src/SolARPoseEstimationPnpEPFL.cpp
     src/SolARPoseEstimationPnpOpencv.cpp
 	src/SolARPoseEstimationSACPnpOpencv.cpp
@@ -79,6 +80,7 @@ set (HEADERS
     interfaces/SolARDescriptorMatcherRadiusOpencv.h
     interfaces/SolARFundamentalMatrixEstimationOpencv.h
     interfaces/SolARSVDFundamentalMatrixDecomposerOpencv.h
+	interfaces/SolARPoseEstimationPlanarPointsOpencv.h
     interfaces/SolARPoseEstimationPnpEPFL.h
     interfaces/SolARPoseEstimationPnpOpencv.h
 	interfaces/SolARPoseEstimationSACPnpOpencv.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.7.2)
 
 ##################################################
-set (VERSION_NUMBER "0.5.1")
+set (VERSION_NUMBER "0.5.2")
 project("SolARModuleOpenCV")
 set (SOURCES 
     src/SolARModuleOpencv.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ set (SOURCES
     src/AKAZE2/fed.cpp
     src/AKAZE2/nldiffusion_functions.cpp
     src/SolARSVDTriangulationOpencv.cpp
+	src/SolAROpticalFlowPytLKOpencv.cpp
     src/SolARFundamentalMatrixEstimationOpencv.cpp
     src/SolARSVDFundamentalMatrixDecomposerOpencv.cpp
     src/SolARImageFilterBinaryOpencv.cpp
@@ -84,6 +85,7 @@ set (HEADERS
     interfaces/SolARGeometricMatchesFilterOpencv.h
     interfaces/SolAR2DOverlayOpencv.h
     interfaces/SolARSVDTriangulationOpencv.h
+	interfaces/SolAROpticalFlowPyrLKOpencv.h
     src/AKAZE2/AKAZEConfig.h
     src/AKAZE2/AKAZEFeatures.h
     src/AKAZE2/fed.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ set (SOURCES
     src/SolARContoursExtractorOpencv.cpp
     src/SolARPerspectiveControllerOpencv.cpp
     src/SolARProjectOpencv.cpp
-    src/SolARUnprojectPlanarPointsOpencv.cpp
+    src/SolARUnprojectplanarPointsOpencv.cpp
     src/SolARMarker2DSquaredBinaryOpencv.cpp
     src/SolARContoursFilterBinaryMarkerOpencv.cpp
     src/SolARDescriptorsExtractorSBPatternOpencv.cpp

--- a/SolARModuleOpenCV.pro
+++ b/SolARModuleOpenCV.pro
@@ -66,6 +66,7 @@ HEADERS += interfaces/SolARCameraOpencv.h \
     interfaces/SolARDescriptorMatcherRadiusOpencv.h \
     interfaces/SolARFundamentalMatrixEstimationOpencv.h \
     interfaces/SolARSVDFundamentalMatrixDecomposerOpencv.h\
+    interfaces/SolARPoseEstimationPlanarPointsOpencv.h \
     interfaces/SolARPoseEstimationPnpEPFL.h \
     interfaces/SolARPoseEstimationPnpOpencv.h \
     interfaces/SolARPoseEstimationSACPnpOpencv.h \
@@ -117,6 +118,7 @@ SOURCES += src/SolARModuleOpencv.cpp \
     src/SolARGeometricMatchesFilterOpencv.cpp \
     src/SolAR2DOverlayOpencv.cpp \
     src/SolARHomographyEstimationOpencv.cpp \
+    src/SolARPoseEstimationPlanarPointsOpencv.cpp \
     src/SolARPoseEstimationPnpEPFL.cpp \
     src/SolARPoseEstimationPnpOpencv.cpp \
     src/SolARPoseEstimationSACPnpOpencv.cpp \

--- a/SolARModuleOpenCV.pro
+++ b/SolARModuleOpenCV.pro
@@ -6,7 +6,7 @@ CONFIG -= qt
 TARGET = SolARModuleOpenCV
 INSTALLSUBDIR = bcomBuild
 FRAMEWORK = $$TARGET
-VERSION=0.5.1
+VERSION=0.5.2
 
 DEFINES += MYVERSION=$${VERSION}
 DEFINES += TEMPLATE_LIBRARY
@@ -72,6 +72,7 @@ HEADERS += interfaces/SolARCameraOpencv.h \
     interfaces/SolARGeometricMatchesFilterOpencv.h \
     interfaces/SolAR2DOverlayOpencv.h \
     interfaces/SolARSVDTriangulationOpencv.h \
+    interfaces/SolAROpticalFlowPyrLKOpencv.h \
     src/AKAZE2/AKAZEConfig.h \
     src/AKAZE2/AKAZEFeatures.h \
     src/AKAZE2/fed.h \
@@ -125,6 +126,7 @@ SOURCES += src/SolARModuleOpencv.cpp \
     src/AKAZE2/fed.cpp \
     src/AKAZE2/nldiffusion_functions.cpp \
     src/SolARSVDTriangulationOpencv.cpp \
+    src/SolAROpticalFlowPyrLKOpencv.cpp \
     src/SolARFundamentalMatrixEstimationOpencv.cpp \
     src/SolARSVDFundamentalMatrixDecomposerOpencv.cpp \
     src/SolARImageFilterBinaryOpencv.cpp \
@@ -139,7 +141,7 @@ SOURCES += src/SolARModuleOpencv.cpp \
     src/SolARHomographyMatrixDecomposerOpencv.cpp \
     src/SolARPoseFinderFrom2D2DOpencv.cpp \
     src/SolARMatchesOverlayOpencv.cpp \
-	src/SolARUndistortPointsOpencv.cpp
+    src/SolARUndistortPointsOpencv.cpp
 
 unix {
     QMAKE_CXXFLAGS += -Wignored-qualifiers

--- a/SolARModuleOpenCV.pro
+++ b/SolARModuleOpenCV.pro
@@ -48,12 +48,15 @@ HEADERS += interfaces/SolARCameraOpencv.h \
     interfaces/SolARImageLoaderOpencv.h \
     interfaces/SolARImageViewerOpencv.h \
     interfaces/SolARKeypointDetectorOpencv.h \
+    interfaces/SolARKeypointDetectorRegionOpencv.h \
     interfaces/SolAROpenCVHelper.h \
     interfaces/SolAROpencvAPI.h \
     interfaces/SolARCameraCalibrationOpencv.h \
     interfaces/SolARMarker2DNaturalImageOpencv.h \
     interfaces/SolARContoursExtractorOpencv.h \
     interfaces/SolARPerspectiveControllerOpencv.h \
+    interfaces/SolARProjectOpencv.h \
+    interfaces/SolARUnprojectPlanarPointsOpencv.h \
     interfaces/SolARMarker2DSquaredBinaryOpencv.h \
     interfaces/SolARContoursFilterBinaryMarkerOpencv.h \
     interfaces/SolARDescriptorsExtractorSBPatternOpencv.h \
@@ -97,6 +100,7 @@ HEADERS += interfaces/SolARCameraOpencv.h \
 
 SOURCES += src/SolARModuleOpencv.cpp \
     src/SolARKeypointDetectorOpencv.cpp \
+    src/SolARKeypointDetectorRegionOpencv.cpp \
     src/SolARImageLoaderOpencv.cpp \
     src/SolARImageConvertorOpencv.cpp \
     src/SolARImageConvertorUnity.cpp \
@@ -107,6 +111,8 @@ SOURCES += src/SolARModuleOpencv.cpp \
     src/SolARMarker2DNaturalImageOpencv.cpp \
     src/SolARContoursExtractorOpencv.cpp \
     src/SolARPerspectiveControllerOpencv.cpp \
+    src/SolARProjectOpencv.cpp \
+    src/SolARUnprojectPlanarPointsOpencv.cpp \
     src/SolARMarker2DSquaredBinaryOpencv.cpp \
     src/SolARContoursFilterBinaryMarkerOpencv.cpp \
     src/SolARDescriptorsExtractorSBPatternOpencv.cpp \

--- a/SolARModuleOpenCV.pro
+++ b/SolARModuleOpenCV.pro
@@ -112,7 +112,7 @@ SOURCES += src/SolARModuleOpencv.cpp \
     src/SolARContoursExtractorOpencv.cpp \
     src/SolARPerspectiveControllerOpencv.cpp \
     src/SolARProjectOpencv.cpp \
-    src/SolARUnprojectPlanarPointsOpencv.cpp \
+    src/SolARUnprojectplanarPointsOpencv.cpp \
     src/SolARMarker2DSquaredBinaryOpencv.cpp \
     src/SolARContoursFilterBinaryMarkerOpencv.cpp \
     src/SolARDescriptorsExtractorSBPatternOpencv.cpp \

--- a/bcom-SolARModuleOpenCV.pc.in
+++ b/bcom-SolARModuleOpenCV.pc.in
@@ -5,7 +5,7 @@ libdir=${exec_prefix}/lib
 includedir=${prefix}/interfaces
 Name: SolARModuleOpenCV
 Description:
-Version: 0.5.1
+Version: 0.5.2
 Requires:
 Libs: -L${libdir} -l${libname}
 Libs.private: ${libdir}/${pfx}${libname}.${lext}

--- a/interfaces/SolAR2DOverlayOpencv.h
+++ b/interfaces/SolAR2DOverlayOpencv.h
@@ -35,16 +35,39 @@ class SOLAROPENCV_EXPORT_API SolAR2DOverlayOpencv : public org::bcom::xpcf::Conf
 public:
     SolAR2DOverlayOpencv();
 
+    /// @brief Draw one Circle.
+    /// Draw a circle on the image displayImage center on the point with specified radius and thickness.
+    /// @param[in] point The position of the circle to draw
+    /// @param[in,out] displayImage The image on which the the circles will be drawn.
     void drawCircle(const SRef<Point2Df> point, SRef<Image> displayImage) override;
 
+    /// @brief Draw Circles.
+    /// Draw all the circles stored in the vector std::vector <SRef<Point2Df>> & points on image displayImage with specified radius, thickness and colors (defined in the configuration file).
+    /// @param[in] point The positions of the circles to draw
+    /// @param[in,out] displayImage The image on which the circles will be drawn.
     void drawCircles(const std::vector<SRef<Point2Df>>& points, SRef<Image> displayImage) override;
 
     /// @brief Draw Circles.
-    /// Draw all the circles stored in the vector std::vector <SRef<Keypoint>> & keypoints on image displayImage with specified radius and thickness.
+    /// Draw all the circles stored in the vector std::vector <SRef<Keypoint>> & keypoints on image displayImage with specified radius, thickness and colors (defined in the configuration file).
+    /// @param[in] keypoint The positions of the circles to draw
+    /// @param[in,out] displayImage The image on which the circles will be drawn.
     void drawCircles(const std::vector<SRef<Keypoint>>& keypoints, SRef<Image> displayImage) override;
 
+    /// @brief Draw a Contour.
+    /// Draw a contour on image displayImage
+    /// @param[in] contour The contour in 2D to draw with specified radius, thickness and colors (defined in the configuration file).
+    /// @param[in,out] displayImage The image on which the contours will be drawn.
+    void drawContour (const Contour2Df& contour, SRef<Image> displayImage);
+
+    /// @brief Draw Contours.
+    /// Draw all the contours stored in the vector  std::vector <SRef<Contour2Df>> & contours on image displayImage
+    /// @param[in] contours The vector of contours in 2D to draw with specified radius, thickness and colors (defined in the configuration file).
+    /// @param[in,out] displayImage The image on which the contours will be drawn.
     void drawContours (const std::vector <SRef<Contour2Df>> & contours, SRef<Image> displayImage) override;
 
+    /// @brief Draw a Squared Binary Pattern.
+    /// @param[in] pattern The squared binary pattern to display.
+    /// @param[in,out] displayImage The image on which the squared binary pattern will be drawn (on the whole image).
     void drawSBPattern (const SRef<SquaredBinaryPattern> pattern, SRef<Image> displayImage) override;
 
     void unloadComponent () override final;

--- a/interfaces/SolARKeypointDetectorOpencv.h
+++ b/interfaces/SolARKeypointDetectorOpencv.h
@@ -46,10 +46,10 @@ public:
 
     org::bcom::xpcf::XPCFErrorCode onConfigured() override final;
 
-    void setType(KeypointDetectorType type);
+    void setType(KeypointDetectorType type) override;
     KeypointDetectorType  getType();
  
-    void detect (const SRef<Image> &image, std::vector<SRef<Keypoint>> &keypoints);
+    void detect (const SRef<Image> &image, std::vector<SRef<Keypoint>> &keypoints) override;
 
 private:
     /// @brief the type of descriptor used for the extraction (AKAZE, AKAZE2, ORB, BRISK)

--- a/interfaces/SolARKeypointDetectorRegionOpencv.h
+++ b/interfaces/SolARKeypointDetectorRegionOpencv.h
@@ -1,0 +1,101 @@
+/**
+ * @copyright Copyright (c) 2017 B-com http://www.b-com.com/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SOLARKEYPOINTDETECTORREGIONOPENCV_H
+#define SOLARKEYPOINTDETECTORREGIONOPENCV_H
+
+#include "api/features/IKeypointDetectorRegion.h"
+
+// Definition of SolARKeypointDetectorOpencv Class //
+// part of SolAR namespace //
+
+#include "xpcf/component/ConfigurableBase.h"
+#include "SolAROpencvAPI.h"
+#include <string>
+#include "opencv2/opencv.hpp"
+#include "features2d_akaze2.hpp"  // Define AKAZE2;
+
+
+
+namespace SolAR {
+using namespace datastructure;
+using namespace api::features;
+namespace MODULES {
+namespace OPENCV {
+
+class SOLAROPENCV_EXPORT_API SolARKeypointDetectorRegionOpencv : public org::bcom::xpcf::ConfigurableBase,
+        public IKeypointDetectorRegion {
+public:
+
+    /// @brief SolARKeypointDetectorRegionOpencv default constructor
+    SolARKeypointDetectorRegionOpencv();
+
+    /// @brief SolARKeypointDetectorRegionOpencv default destructor
+    ~SolARKeypointDetectorRegionOpencv();
+
+    org::bcom::xpcf::XPCFErrorCode onConfigured() override final;
+
+    /// @brief Set the type of method used to detect keypoints in the image
+    /// @param[in] type The type of method used to detect keypoints.
+    void setType(KeypointDetectorType type) override;
+
+    /// @brief Get the type of method used to detect keypoints in the image
+    /// @return The type of method used to detect keypoints.
+    KeypointDetectorType  getType() override;
+ 
+    /// @brief This method detects keypoints in an input Image
+    /// @param[in] image input image on which we are extracting keypoints.
+    /// @param[in] contours a set of 2D points defining the contour of the region where keypoints will be detected
+    /// @param[out] keypoints The keypoints detected from the given region of the image passed as first argument.
+    void detect (const SRef<Image> &image, const std::vector<SRef<Point2Df>>& contours, std::vector<SRef<Keypoint>> &keypoints) override;
+
+    /// @brief This method detects keypoints in an input Image
+    /// @param[in] image input image on which we are extracting keypoints.
+    /// /// @param[in] contours the contour of the region where keypoints will be detected
+    /// @param[out] keypoints The keypoints detected from the given region of the image passed as first argument.
+    void detect (const SRef<Image> &image, const SRef<Contour2Df> contours, std::vector<SRef<Keypoint>> &keypoints) override;
+
+    void unloadComponent () override final;
+
+private:
+    /// @brief the type of descriptor used for the extraction (AKAZE, AKAZE2, ORB, BRISK)
+    std::string m_type = "AKAZE2";
+
+    /// @brief the ratio to apply to the size of the input image to compute the descriptor.
+    /// A ratio must be less or equal to 1. A ratio less than 1 will speedup computation
+    float m_imageRatio=1.0f;
+
+    /// @brief the number of descriptors that are selected. If negative, all extracted descriptors are selected
+    int m_nbDescriptors = 10000;
+
+	/// @brief the threshold of detector to accept a keypoint
+	float m_threshold = 1e-3;
+
+    int m_id;
+    cv::Ptr<cv::Feature2D> m_detector;
+    cv::KeyPointsFilter kptsFilter;
+
+};
+
+extern int deduceOpenCVType(SRef<Image> img);
+
+}
+}
+}  // end of namespace SolAR
+
+
+
+#endif // SOLARKEYPOINTDETECTORREGIONOPENCV_H

--- a/interfaces/SolARKeypointDetectorRegionOpencv.h
+++ b/interfaces/SolARKeypointDetectorRegionOpencv.h
@@ -62,12 +62,6 @@ public:
     /// @param[out] keypoints The keypoints detected from the given region of the image passed as first argument.
     void detect (const SRef<Image> &image, const std::vector<SRef<Point2Df>>& contours, std::vector<SRef<Keypoint>> &keypoints) override;
 
-    /// @brief This method detects keypoints in an input Image
-    /// @param[in] image input image on which we are extracting keypoints.
-    /// /// @param[in] contours the contour of the region where keypoints will be detected
-    /// @param[out] keypoints The keypoints detected from the given region of the image passed as first argument.
-    void detect (const SRef<Image> &image, const SRef<Contour2Df> contours, std::vector<SRef<Keypoint>> &keypoints) override;
-
     void unloadComponent () override final;
 
 private:

--- a/interfaces/SolARMarker2DNaturalImageOpencv.h
+++ b/interfaces/SolARMarker2DNaturalImageOpencv.h
@@ -39,6 +39,16 @@ public:
     FrameworkReturnCode loadMarker() override;
     FrameworkReturnCode getImage(SRef<Image> & img) override;
 
+    /// @brief Provide the position of 2D corners in image coordinate system
+    /// @param[out] imageCorners the 2D corners of the marker in image coordinate system
+    /// @return FrameworkReturnCode::_SUCCESS if sucessful, eiher FrameworkRetunrnCode::_ERROR_.
+    FrameworkReturnCode getImageCorners(std::vector<SRef<Point2Df>>& imageCorners) const override;
+
+    /// @brief Provide the position of 3D corners in world coordinate system
+    /// @param[out] worldCorners the 3D corners of the marker in world coordinate system
+    /// @return FrameworkReturnCode::_SUCCESS if sucessful, eiher FrameworkRetunrnCode::_ERROR_.
+    FrameworkReturnCode getWorldCorners(std::vector<SRef<Point3Df>>& worldCorners) const override;
+
  private:
      cv::Mat m_ocvImage;
 

--- a/interfaces/SolARMarker2DSquaredBinaryOpencv.h
+++ b/interfaces/SolARMarker2DSquaredBinaryOpencv.h
@@ -42,6 +42,16 @@ public:
 
     FrameworkReturnCode loadMarker() override;
 
+    /// @brief Provide the position of 2D corners in image coordinate system
+    /// @param[out] imageCorners the 2D corners of the marker in image coordinate system
+    /// @return FrameworkReturnCode::_SUCCESS if sucessful, eiher FrameworkRetunrnCode::_ERROR_.
+    FrameworkReturnCode getImageCorners(std::vector<SRef<Point2Df>>& imageCorners) const override;
+
+    /// @brief Provide the position of 3D corners in world coordinate system
+    /// @param[out] worldCorners the 3D corners of the marker in world coordinate system
+    /// @return FrameworkReturnCode::_SUCCESS if sucessful, eiher FrameworkRetunrnCode::_ERROR_.
+    FrameworkReturnCode getWorldCorners(std::vector<SRef<Point3Df>>& worldCorners) const override;
+
     void unloadComponent () override final;
 
  private:

--- a/interfaces/SolARModuleOpencv_traits.h
+++ b/interfaces/SolARModuleOpencv_traits.h
@@ -55,6 +55,7 @@ class SolARMarker2DSquaredBinaryOpencv;
 class SolARMatchesOverlayOpencv;
 class SolAROpticalFlowPyrLKOpencv;
 class SolARPerspectiveControllerOpencv;
+class SolARPoseEstimationPlanarPointsOpencv;
 class SolARPoseEstimationPnpEPFL;
 class SolARPoseEstimationPnpOpencv;
 class SolARPoseEstimationSACPnpOpencv;
@@ -227,6 +228,11 @@ XPCF_DEFINE_COMPONENT_TRAITS(SolAR::MODULES::OPENCV::SolARPerspectiveControllerO
                              "9c960f2a-cd6e-11e7-abc4-cec278b6b50a",
                              "SolARPerspectiveControllerOpencv",
                              "SolAR::MODULES::OPENCV::SolARPerspectiveControllerOpencv component")
+
+XPCF_DEFINE_COMPONENT_TRAITS(SolAR::MODULES::OPENCV::SolARPoseEstimationPlanarPointsOpencv,
+                             "9fbadf80-251f-4160-94f8-a64dc3d40a2f",
+                             "SolARPoseEstimationPlanarPointsEPFL",
+                             "Estimates the camera pose from 2D-3D planar points correspodances")
 
 XPCF_DEFINE_COMPONENT_TRAITS(SolAR::MODULES::OPENCV::SolARPoseEstimationPnpEPFL,
                              "a38edf79-f0dc-45ca-92fc-2b336fceedf9",

--- a/interfaces/SolARModuleOpencv_traits.h
+++ b/interfaces/SolARModuleOpencv_traits.h
@@ -50,11 +50,14 @@ class SolARImageLoaderOpencv;
 class SolARImageViewerOpencv;
 class SolARImagesAsCameraOpencv;
 class SolARKeypointDetectorOpencv;
+class SolARKeypointDetectorRegionOpencv;
 class SolARMarker2DNaturalImageOpencv;
 class SolARMarker2DSquaredBinaryOpencv;
 class SolARMatchesOverlayOpencv;
 class SolAROpticalFlowPyrLKOpencv;
 class SolARPerspectiveControllerOpencv;
+class SolARProjectOpencv;
+class SolARUnprojectPlanarPointsOpencv;
 class SolARPoseEstimationPlanarPointsOpencv;
 class SolARPoseEstimationPnpEPFL;
 class SolARPoseEstimationPnpOpencv;
@@ -209,6 +212,11 @@ XPCF_DEFINE_COMPONENT_TRAITS(SolAR::MODULES::OPENCV::SolARKeypointDetectorOpencv
                              "SolARKeypointDetectorOpencv",
                              "SolAR::MODULES::OPENCV::SolARKeypointDetectorOpencv component")
 
+XPCF_DEFINE_COMPONENT_TRAITS(SolAR::MODULES::OPENCV::SolARKeypointDetectorRegionOpencv,
+                             "22c2ca9f-e43b-4a88-8337-4a166a789971",
+                             "SolARKeypointDetectorRegionOpencv",
+                             "SolAR::MODULES::OPENCV::SolARKeypointDetectorRegionOpencv component")
+
 XPCF_DEFINE_COMPONENT_TRAITS(SolAR::MODULES::OPENCV::SolAROpticalFlowPyrLKOpencv,
                              "b513e9ff-d2e7-4dcf-9a29-4ed95c512158",
                              "SolAROpticalFlowPyrLKOpencv",
@@ -229,6 +237,16 @@ XPCF_DEFINE_COMPONENT_TRAITS(SolAR::MODULES::OPENCV::SolARPerspectiveControllerO
                              "SolARPerspectiveControllerOpencv",
                              "SolAR::MODULES::OPENCV::SolARPerspectiveControllerOpencv component")
 
+XPCF_DEFINE_COMPONENT_TRAITS(SolAR::MODULES::OPENCV::SolARProjectOpencv,
+                             "741fc298-0149-4322-a7a9-ccb971e857ba",
+                             "SolARProjectOpencv",
+                             "SolAR::MODULES::OPENCV::SolARProjectOpencv component")
+
+XPCF_DEFINE_COMPONENT_TRAITS(SolAR::MODULES::OPENCV::SolARUnprojectPlanarPointsOpencv,
+                             "9938354d-6476-437e-8325-97e82666a46e",
+                             "SolARUnprojectPlanarPointsOpencv",
+                             "SolAR::MODULES::OPENCV::SolARUnprojectPlanarPointsOpencv component")
+
 XPCF_DEFINE_COMPONENT_TRAITS(SolAR::MODULES::OPENCV::SolARPoseEstimationPlanarPointsOpencv,
                              "9fbadf80-251f-4160-94f8-a64dc3d40a2f",
                              "SolARPoseEstimationPlanarPointsEPFL",
@@ -238,7 +256,6 @@ XPCF_DEFINE_COMPONENT_TRAITS(SolAR::MODULES::OPENCV::SolARPoseEstimationPnpEPFL,
                              "a38edf79-f0dc-45ca-92fc-2b336fceedf9",
                              "SolARPoseEstimationPnpEPFL",
                              "SolAR::MODULES::OPENCV::SolARPoseEstimationPnpEPFL component")
-
 
 XPCF_DEFINE_COMPONENT_TRAITS(SolAR::MODULES::OPENCV::SolARPoseEstimationPnpOpencv,
                              "0753ade1-7932-4e29-a71c-66155e309a53",

--- a/interfaces/SolARModuleOpencv_traits.h
+++ b/interfaces/SolARModuleOpencv_traits.h
@@ -53,6 +53,7 @@ class SolARKeypointDetectorOpencv;
 class SolARMarker2DNaturalImageOpencv;
 class SolARMarker2DSquaredBinaryOpencv;
 class SolARMatchesOverlayOpencv;
+class SolAROpticalFlowPyrLKOpencv;
 class SolARPerspectiveControllerOpencv;
 class SolARPoseEstimationPnpEPFL;
 class SolARPoseEstimationPnpOpencv;
@@ -206,6 +207,11 @@ XPCF_DEFINE_COMPONENT_TRAITS(SolAR::MODULES::OPENCV::SolARKeypointDetectorOpencv
                              "e81c7e4e-7da6-476a-8eba-078b43071272",
                              "SolARKeypointDetectorOpencv",
                              "SolAR::MODULES::OPENCV::SolARKeypointDetectorOpencv component")
+
+XPCF_DEFINE_COMPONENT_TRAITS(SolAR::MODULES::OPENCV::SolAROpticalFlowPyrLKOpencv,
+                             "b513e9ff-d2e7-4dcf-9a29-4ed95c512158",
+                             "SolAROpticalFlowPyrLKOpencv",
+                             "A component to estimate the optical flow between two images based on pyramidal Lucas-Kanade approach")
 
 XPCF_DEFINE_COMPONENT_TRAITS(SolAR::MODULES::OPENCV::SolARMarker2DNaturalImageOpencv,
                              "efcdb590-c570-11e7-abc4-cec278b6b50a",

--- a/interfaces/SolAROpenCVHelper.h
+++ b/interfaces/SolAROpenCVHelper.h
@@ -58,13 +58,13 @@ public:
 
     static void drawCVLine (cv::Mat& inputImage, cv::Point2f& p1, cv::Point2f& p2, cv::Scalar color, int thickness);
 
-private:
-    template <class T> inline static constexpr int inferOpenCVType();
+	template <class T> inline static constexpr int inferOpenCVType();
+ 
     static int deduceOpenCVType(SRef<Image> img);
 
 };
 
-template <class T> constexpr int inferOpenCVType()
+template <class T> constexpr int SolAROpenCVHelper::inferOpenCVType()
 {
     static_assert(std::is_same<T, double>::value || std::is_same<T, float>::value || std::is_same<T, int32_t>::value
                    || std::is_same<T, int16_t>::value || std::is_same<T, unsigned char>::value || std::is_same<T, char>::value,

--- a/interfaces/SolAROpticalFlowPyrLKOpencv.h
+++ b/interfaces/SolAROpticalFlowPyrLKOpencv.h
@@ -1,0 +1,111 @@
+/**
+ * @copyright Copyright (c) 2017 B-com http://www.b-com.com/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SOLAROPTICALFLOWPYRLKOPENCV_H
+#define SOLAROPTICALFLOWPYRLKOPENCV_H
+
+#include "api/tracking/IOpticalFlowEstimator.h"
+
+// Definition of SolAROpticalFlowPyrLKOpencv Class //
+// part of SolAR namespace //
+
+#include "xpcf/component/ConfigurableBase.h"
+#include "SolAROpencvAPI.h"
+#include <string>
+#include "opencv2/video/tracking.hpp""
+
+#include "datastructure/Image.h"
+#include "datastructure/Keypoint.h"
+
+namespace SolAR {
+using namespace datastructure;
+using namespace api::tracking;
+namespace MODULES {
+namespace OPENCV {
+
+class SOLAROPENCV_EXPORT_API SolAROpticalFlowPyrLKOpencv : public org::bcom::xpcf::ConfigurableBase,
+        public api::tracking::IOpticalFlowEstimator {
+public:
+    SolAROpticalFlowPyrLKOpencv();
+    ~SolAROpticalFlowPyrLKOpencv();
+    void unloadComponent () override final;
+
+    /// @brief estimate the optical flow between two images
+    /// @param[in] previousImage The previous image
+    /// @param[in] currentImage The current image for which we want to estimate the optical flow relative to the previous image
+    /// @param[in] pointsToTrack The pixels to track in the previous image
+    /// @param[out] trackedPoints The position of the pointsToTrack in the current image
+    /// @param[out] status Specify for each point; each element of the vector is set to 1 if the flow for the corresponding features has been found, otherwise, it is set to 0.
+    /// @param[out] error Specify for each point the tracking error
+    FrameworkReturnCode estimate(const SRef<Image> previousImage,
+                                 const SRef<Image> currentImage,
+                                 const std::vector<SRef<Keypoint>> & pointsToTrack,
+                                 std::vector<SRef<Point2Df>> & trackedPoints,
+                                 std::vector<unsigned char> & status,
+                                 std::vector<float> & error);
+
+    /// @brief estimate the optical flow between two images
+    /// @param[in] previousImage The previous image
+    /// @param[in] currentImage The current image for which we want to estimate the optical flow relative to the previous image
+    /// @param[in] pointsToTrack The pixels to track in the previous image
+    /// @param[out] trackedPoints The position of the pointsToTrack in the current image
+    /// @param[out] status Specify for each point; each element of the vector is set to 1 if the flow for the corresponding features has been found, otherwise, it is set to 0.
+    /// @param[out] error Specify for each point the tracking error
+    FrameworkReturnCode estimate(const SRef<Image> previousImage,
+                                 const SRef<Image> currentImage,
+                                 const std::vector<SRef<Point2Df>> & pointsToTrack,
+                                 std::vector<SRef<Point2Df>> & trackedPoints,
+                                 std::vector<unsigned char> & status,
+                                 std::vector<float> & error);
+
+private:
+
+    /// @brief WidthHeight in pixels of the search window at each pyramid level
+    int m_searchWinWidth = 21;
+
+    /// @brief Height in pixels of the search window at each pyramid level
+    int m_searchWinHeight = 21;
+
+    /// @brief maximum level of pyramid
+    /// If set to 0, pyramids are not used (single level), if set to 1, two levels are used, and so on; if pyramids are passed to input then algorithm will use as many levels as pyramids have but no more than maxLevel.
+    int m_maxLevel = 3;
+
+    /// The minimum eigen value to measure error
+    /// The algorithm calculates the minimum eigen value of a 2x2 normal matrix of optical flow equations (this matrix is called a spatial gradient matrix in [16]), divided by number of pixels in a window.
+    /// If this value is less than minEigThreshold, then a corresponding feature is filtered out and its flow is not processed, so it allows to remove bad points and get a performance boost.
+    /// If this value is less or equal to 0, the minimum eigen values as an error measure are not used. Instead, the L1 distance between patches around the original and a moved point, divided by number of pixels in a window, is used as a error measure.
+    double m_minEigenThreshold = -1.0;
+
+    // The maximum iteration before iterative search algorithm stops.
+    int m_maxSearchIterations = 20;
+
+    // The desired accuracy of the search window before algorithm stops.
+    float m_searchWindowAccuracy = 0.03;
+
+
+    FrameworkReturnCode estimate(const SRef<Image> previousImage,
+                                 const SRef<Image> currentImage,
+                                 const std::vector<cv::Point2f> & pointsToTrack,
+                                 std::vector<SRef<Point2Df>> & trackedPoints,
+                                 std::vector<unsigned char> & status,
+                                 std::vector<float> & error);
+};
+
+}
+}
+}  // end of namespace SolAR
+
+#endif // SOLAROPTICALFLOWPYRLKOPENCV_H

--- a/interfaces/SolARPoseEstimationPlanarPointsOpencv.h
+++ b/interfaces/SolARPoseEstimationPlanarPointsOpencv.h
@@ -1,0 +1,82 @@
+/**
+ * @copyright Copyright (c) 2017 B-com http://www.b-com.com/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SOLARPOSEESTIMATIONPLANARPOINTSOPENCV_H
+#define SOLARPOSEESTIMATIONPLANARPOINTSOPENCV_H
+#include <vector>
+#include "opencv2/core.hpp"
+#include "api/solver/pose/I3DTransformSACFinderFrom2D3D.h"
+#include "datastructure/Image.h"
+#include "SolAROpencvAPI.h"
+#include "xpcf/component/ConfigurableBase.h"
+
+namespace SolAR {
+using namespace datastructure;
+namespace MODULES {
+namespace OPENCV {
+    /**
+     * @class SolARPoseEstimationPlanarPointsOpencv
+     * @brief Finds the camera pose of 2D-3D planar points correspondances based on opencv homography.
+     */
+    class SOLAROPENCV_EXPORT_API SolARPoseEstimationPlanarPointsOpencv : public org::bcom::xpcf::ConfigurableBase,
+        public api::solver::pose::I3DTransformSACFinderFrom2D3D
+    {
+    public:
+        ///@brief SolARPoseEstimationPlanarPointsOpencv constructor;
+        SolARPoseEstimationPlanarPointsOpencv();
+        ///@brief SolARPoseEstimationPlanarPointsOpencv destructor;
+        ~SolARPoseEstimationPlanarPointsOpencv();
+
+        /// @brief Estimates camera pose from a set of 2D image points of their corresponding 3D  world points.
+        /// @param[in] imagePoints, set of 2d_points seen in view_1.
+        /// @param[in]  worldPoints, set of 3d_points corresponding to view_1.
+        /// @param[out] imagePoints_inlier, image 2d points that are inliers
+        /// @param[out] worldPoints_inlier, world 3d points that are inliers.
+        /// @param[out] pose, camera pose (pose the camera defined in world corrdinate system) expressed as a Transform3D.
+        /// @param[in] initialPose (Optional), a tranfsform3D to initialize the pose (reducing the convergence time and improving its success). If your world points are planar, do not use this argument.
+        FrameworkReturnCode estimate(const std::vector<SRef<Point2Df>> & imagePoints,
+                                     const std::vector<SRef<Point3Df>> & worldPoints,
+                                     std::vector<SRef<Point2Df>>&imagePoints_inlier,
+                                     std::vector<SRef<Point3Df>>&worldPoints_inlier,
+                                     Transform3Df & pose,
+                                     const Transform3Df initialPose = Transform3Df::Identity()) override;
+
+        /// @brief this method is used to set intrinsic parameters and distorsion of the camera
+        /// @param[in] Camera calibration matrix parameters.
+        /// @param[in] Camera distorsion parameters.
+        void setCameraParameters(const CamCalibration & intrinsicParams,
+                                 const CamDistortion & distorsionParams)  override;
+
+        void unloadComponent () override final;
+
+
+    private:
+
+        // minimal number of inliers to validate the pose
+        int m_minNbInliers = 10;
+
+        /// @brief Inlier threshold value used by the RANSAC procedure. The parameter value is the maximum allowed distance between the observed and computed point projections to consider it an inlier.
+        float m_reprojErrorThreshold = 0.1;
+
+
+        cv::Mat m_camMatrix;
+        cv::Mat m_camDistorsion;
+    };
+}
+}
+}
+
+#endif // SOLARPOSEESTIMATIONPLANARPOINTSOPENCV_H

--- a/interfaces/SolARProjectOpencv.h
+++ b/interfaces/SolARProjectOpencv.h
@@ -1,0 +1,65 @@
+/**
+ * @copyright Copyright (c) 2017 B-com http://www.b-com.com/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SOLARPROJECTOPENCV_H
+#define SOLARPROJECTOPENCV_H
+#include <vector>
+#include "opencv2/core.hpp"
+#include "api/geom/IProject.h"
+#include "SolAROpencvAPI.h"
+#include "xpcf/component/ConfigurableBase.h"
+
+namespace SolAR {
+    using namespace datastructure;
+    namespace MODULES {
+        namespace OPENCV {
+        /**
+         * @class SolARProjectOpencv
+         * @brief a component to project 3D points on the 2D image plane
+         */
+            class SOLAROPENCV_EXPORT_API SolARProjectOpencv : public org::bcom::xpcf::ConfigurableBase,
+                public api::geom::IProject
+            {
+            public:
+                ///@brief SolARProjectOpencv constructor;
+                SolARProjectOpencv();
+                ///@brief SolARProjectOpencv destructor;
+                ~SolARProjectOpencv();
+
+                /// @brief this method is used to set intrinsic parameters and distorsion of the camera
+                /// @param[in] Camera calibration matrix parameters.
+                /// @param[in] Camera distorsion parameters.
+                void setCameraParameters(const CamCalibration & intrinsicParams, const CamDistortion & distorsionParams) override;
+
+                /// @brief This method project a set of 3D points in the image plane
+                /// @param[in] inputPoints the set of 3D points to project
+                /// @param[in] pose the 3D pose of the camera (a 4x4 float matrix)
+                /// @param[out] outputPoints the resulting set of 2D points define in the image coordinate systemn
+                /// @return FrameworkReturnCode::_SUCCESS_ if 3D projection succeed, else FrameworkReturnCode::_ERROR.
+                FrameworkReturnCode project(const std::vector<SRef<Point3Df>> & inputPoints, const Transform3Df& pose, std::vector<SRef<Point2Df>> & imagePoints) override;
+
+                void unloadComponent () override final;
+
+
+            private:
+                cv::Mat m_camMatrix;
+                cv::Mat m_camDistorsion;
+            };
+}
+}
+}
+
+#endif // SOLARPROJECTOPENCV_H

--- a/interfaces/SolARProjectOpencv.h
+++ b/interfaces/SolARProjectOpencv.h
@@ -49,7 +49,7 @@ namespace SolAR {
                 /// @param[in] pose the 3D pose of the camera (a 4x4 float matrix)
                 /// @param[out] outputPoints the resulting set of 2D points define in the image coordinate systemn
                 /// @return FrameworkReturnCode::_SUCCESS_ if 3D projection succeed, else FrameworkReturnCode::_ERROR.
-                FrameworkReturnCode project(const std::vector<SRef<Point3Df>> & inputPoints, const Transform3Df& pose, std::vector<SRef<Point2Df>> & imagePoints) override;
+                FrameworkReturnCode project(const std::vector<SRef<Point3Df>> & inputPoints, std::vector<SRef<Point2Df>> & imagePoints, const Transform3Df& pose = Transform3Df::Identity()) override;
 
                 void unloadComponent () override final;
 

--- a/interfaces/SolARUnprojectPlanarPointsOpencv.h
+++ b/interfaces/SolARUnprojectPlanarPointsOpencv.h
@@ -1,0 +1,67 @@
+/**
+ * @copyright Copyright (c) 2017 B-com http://www.b-com.com/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SOLARUNPROJECTPLANARPOINTSOPENCV_H
+#define SOLARUNPROJECTPLANARPOINTSOPENCV_H
+#include <vector>
+#include "opencv2/core.hpp"
+#include "api/geom/IUnproject.h"
+#include "datastructure/Image.h"
+#include "SolAROpencvAPI.h"
+#include "xpcf/component/ConfigurableBase.h"
+
+namespace SolAR {
+    using namespace datastructure;
+    namespace MODULES {
+        namespace OPENCV {
+        /**
+         * @class SolARUnprojectPlanarPointsOpencv
+         * @brief a component to recover 3D points defined in world coordinate system from a set of 2D points defined in the image coordinate system
+         */
+            class SOLAROPENCV_EXPORT_API SolARUnprojectPlanarPointsOpencv : public org::bcom::xpcf::ConfigurableBase,
+                public api::geom::IUnproject
+            {
+            public:
+                ///@brief SolARUnprojectPlanarPointsOpencv constructor;
+                SolARUnprojectPlanarPointsOpencv();
+                ///@brief SolARUnprojectPlanarPointsOpencv destructor;
+                ~SolARUnprojectPlanarPointsOpencv();
+
+                /// @brief this method is used to set intrinsic parameters and distorsion of the camera
+                /// @param[in] Camera calibration matrix parameters.
+                /// @param[in] Camera distorsion parameters.
+                void setCameraParameters(const CamCalibration & intrinsicParams, const CamDistortion & distorsionParams) override;
+
+                /// @brief This method unproject a set of 2D image points in the 3D world coordinate system
+                /// @param[in] imagePoints the set of 2D points to unproject
+                /// @param[in] pose the 3D pose of the camera (a 4x4 float matrix)
+                /// @param[out] worldPoints a set of world 3D points resulting from the unprojection of the 2D image points
+                /// @return FrameworkReturnCode::_SUCCESS_ if 3D projection succeed, else FrameworkReturnCode::_ERROR.
+                FrameworkReturnCode unproject(const std::vector<SRef<Point2Df>> & imagePoints, const Transform3Df& pose, std::vector<SRef<Point3Df>> & worldPoints) override;
+
+
+                void unloadComponent () override final;
+
+
+            private:
+                cv::Mat m_camMatrix;
+                cv::Mat m_camDistorsion;
+            };
+}
+}
+}
+
+#endif // SOLARUNPROJECTPLANARPOINTSOPENCV_H

--- a/interfaces/SolARUnprojectPlanarPointsOpencv.h
+++ b/interfaces/SolARUnprojectPlanarPointsOpencv.h
@@ -50,8 +50,14 @@ namespace SolAR {
                 /// @param[in] pose the 3D pose of the camera (a 4x4 float matrix)
                 /// @param[out] worldPoints a set of world 3D points resulting from the unprojection of the 2D image points
                 /// @return FrameworkReturnCode::_SUCCESS_ if 3D projection succeed, else FrameworkReturnCode::_ERROR.
-                FrameworkReturnCode unproject(const std::vector<SRef<Point2Df>> & imagePoints, const Transform3Df& pose, std::vector<SRef<Point3Df>> & worldPoints) override;
+                FrameworkReturnCode unproject(const std::vector<SRef<Point2Df>> & imagePoints, std::vector<SRef<Point3Df>> & worldPoints, const Transform3Df& pose = Transform3Df::Identity()) override;
 
+                /// @brief This method unproject a set of 2D image points in the 3D world coordinate system
+                /// @param[in] imageKeypoints the set of 2D keypoints to unproject
+                /// @param[in] pose the 3D pose of the camera (a 4x4 float matrix)
+                /// @param[out] worldPoints a set of world 3D points resulting from the unprojection of the 2D image points
+                /// @return FrameworkReturnCode::_SUCCESS_ if 3D projection succeed, else FrameworkReturnCode::_ERROR.
+                FrameworkReturnCode unproject(const std::vector<SRef<Keypoint>> & imageKeypoints, std::vector<SRef<Point3Df>> & worldPoints, const Transform3Df& pose = Transform3Df::Identity()) override;
 
                 void unloadComponent () override final;
 

--- a/packagedependencies.txt
+++ b/packagedependencies.txt
@@ -1,5 +1,5 @@
 opencv|3.4.3|opencv|thirdParties|url_repo_artifactory
-SolARFramework|0.5.1|SolARFramework|bcomBuild|url_repo_artifactory
+SolARFramework|0.5.2|SolARFramework|bcomBuild|url_repo_artifactory
 xpcf|2.1.0|xpcf|thirdParties|http://repository.b-com.com/amc-generic
 boost|1.68.0|boost|thirdParties|http://repository.b-com.com/amc-generic
 spdlog|0.14.0|spdlog|thirdParties|http://repository.b-com.com/amc-generic

--- a/src/SolAR2DOverlayOpencv.cpp
+++ b/src/SolAR2DOverlayOpencv.cpp
@@ -118,32 +118,79 @@ void SolAR2DOverlayOpencv::drawCircles(const std::vector<SRef<Keypoint>>& keypoi
 
 }
 
-void SolAR2DOverlayOpencv::drawContours (const std::vector <SRef<Contour2Df>> & contours, SRef<Image> displayImage)
+void SolAR2DOverlayOpencv::drawContour (const Contour2Df& contour, SRef<Image> displayImage)
+{
+    // image where contours will be displayed
+    cv::Mat displayedImage = SolAROpenCVHelper::mapToOpenCV(displayImage);
+    cv::Scalar color;
+
+    if (!m_randomColor)
+        color = cv::Scalar(m_color[0], m_color[1], m_color[2]);
+    else
+    {
+        std::random_device rd;     // only used once to initialise (seed) engine
+        std::mt19937 rng(rd());    // random-number engine used (Mersenne-Twister in this case)
+        std::uniform_int_distribution<int> uni(0,255); // guaranteed unbiased
+
+        color = cv::Scalar(uni(rng), uni(rng), uni(rng));
+    }
+
+
+    for (int i = 0; i < contour.size(); i++)
+    {
+        if (i != contour.size() - 1)
+        {
+            cv::Point2f pt_a(contour[i]->getX(), contour[i]->getY());
+            cv::Point2f pt_b(contour[i+1]->getX(),contour[i+1]->getY());
+
+            SolAROpenCVHelper::drawCVLine(displayedImage, pt_a, pt_b, cv::Scalar(color[0],color[1], color[2]), m_thickness);
+        }
+        else
+        {
+            //the contours loops to the first point
+            cv::Point2f pt_a(contour[i]->getX(), contour[i]->getY());
+            cv::Point2f pt_b(contour[0]->getX(),contour[0]->getY());
+
+            SolAROpenCVHelper::drawCVLine(displayedImage, pt_a, pt_b, cv::Scalar(color[0],color[1], color[2]), m_thickness);
+        }
+    }
+}
+
+void SolAR2DOverlayOpencv::drawContours (const std::vector<SRef<Contour2Df>> & contours, SRef<Image> displayImage)
 {
     // image where contours will be displayed
     cv::Mat displayedImage = SolAROpenCVHelper::mapToOpenCV(displayImage);
 
-    std::vector<unsigned int> color = m_color;
-    if (m_randomColor)
-        color = {128, 128, 128};
+    cv::Scalar color;
 
     for (std::vector<SRef<Contour2Df>>::const_iterator itr = contours.begin(); itr != contours.end(); itr++)
     {
+        if (!m_randomColor)
+            color = cv::Scalar(m_color[0], m_color[1], m_color[2]);
+        else
+        {
+            std::random_device rd;     // only used once to initialise (seed) engine
+            std::mt19937 rng(rd());    // random-number engine used (Mersenne-Twister in this case)
+            std::uniform_int_distribution<int> uni(0,255); // guaranteed unbiased
+
+            color = cv::Scalar(uni(rng), uni(rng), uni(rng));
+        }
+
         const SRef<const Contour2Df> contour = *itr;
         for (int i = 0; i < contour->size(); i++)
         {
             if (i != contour->size() - 1)
             {
-                cv::Point2f pt_a((*contour)[i][0], (*contour)[i][1]);
-                cv::Point2f pt_b((*contour)[i+1][0],(*contour)[i+1][1]);
+                cv::Point2f pt_a((*contour)[i]->getX(), (*contour)[i]->getY());
+                cv::Point2f pt_b((*contour)[i+1]->getX(),(*contour)[i+1]->getY());
 
                 SolAROpenCVHelper::drawCVLine(displayedImage, pt_a, pt_b, cv::Scalar(color[0],color[1], color[2]), m_thickness);
             }
             else
             {
                 //the contours loops to the first point
-                cv::Point2f pt_a((*contour)[i][0], (*contour)[i][1]);
-                cv::Point2f pt_b((*contour)[0][0],(*contour)[0][1]);
+                cv::Point2f pt_a((*contour)[i]->getX(), (*contour)[i]->getY());
+                cv::Point2f pt_b((*contour)[0]->getX(),(*contour)[0]->getY());
 
                 SolAROpenCVHelper::drawCVLine(displayedImage, pt_a, pt_b, cv::Scalar(color[0],color[1], color[2]), m_thickness);
             }

--- a/src/SolARContoursExtractorOpencv.cpp
+++ b/src/SolARContoursExtractorOpencv.cpp
@@ -59,10 +59,7 @@ namespace OPENCV {
                     SRef<Contour2Df> contour = xpcf::utils::make_shared<Contour2Df>();
                     for (size_t j = 0; j < contourSize; j++)
                     {
-                        Point2Df point;
-                        point[0] = ocv_contours[i][j].x;
-                        point[1] = ocv_contours[i][j].y;
-                        contour->push_back(point);
+                        contour->push_back(xpcf::utils::make_shared<Point2Df>(ocv_contours[i][j].x, ocv_contours[i][j].y));
                     }
                     contours.push_back(contour);
                 }

--- a/src/SolARContoursFilterBinaryMarkerOpencv.cpp
+++ b/src/SolARContoursFilterBinaryMarkerOpencv.cpp
@@ -44,7 +44,7 @@ namespace OPENCV {
         for (size_t i = 0; i<contour.size(); i++)
         {
             size_t i2 = (i + 1) % contour.size();
-            sum += (contour[i]-contour[i2]).norm();
+            sum += ((*(contour[i]))-(*(contour[i2]))).norm();
         }
         return sum;
     }
@@ -75,17 +75,14 @@ namespace OPENCV {
                     SRef<Contour2Df> contour = xpcf::utils::make_shared<Contour2Df>();
                     for (int i = 0; i<4; i++)
                     {
-                        Point2Df pt;
-                        pt[0] = approxCurve[i].x;
-                        pt[1] = approxCurve[i].y;
-                        contour->push_back(pt);
+                        contour->push_back(xpcf::utils::make_shared<Point2Df>(approxCurve[i].x, approxCurve[i].y));
                      }
-                    Point2Df v1 = (*contour)[1] - (*contour)[0];
-                    Point2Df v2 = (*contour)[2] - (*contour)[0];
+                    Point2Df v1 = (*((*contour)[1])) - (*((*contour)[0]));
+                    Point2Df v2 = (*((*contour)[2])) - (*((*contour)[0]));
 
                     double o = (v1[0] * v2[1]) - (v1[1] * v2[0]);
                     if (o < 0.0){		 //if the third point is in the left side, then sort in anti-clockwise order
-                        Point2Df temp_point = (*contour)[3];
+                        SRef<Point2Df> temp_point = (*contour)[3];
                         (*contour)[3] = (*contour)[1];
                         (*contour)[1] = temp_point;
                     }
@@ -105,7 +102,7 @@ namespace OPENCV {
                 float distSquared = 0;
                 for (int c = 0; c < 4; c++)
                 {
-                    Point2Df v = (*(possibleMarkers[i]))[c] - (*(possibleMarkers[j]))[c];
+                    Point2Df v = (*(*(possibleMarkers[i]))[c]) - (*(*(possibleMarkers[j]))[c]);
                     distSquared += v.dot(v);
                 }
                 distSquared /= 4;

--- a/src/SolARKeypointDetectorOpencv.cpp
+++ b/src/SolARKeypointDetectorOpencv.cpp
@@ -109,6 +109,7 @@ void SolARKeypointDetectorOpencv::setType(KeypointDetectorType type)
         break;
 
 
+
     default :
         LOG_DEBUG("KeypointDetectorImp::setType(AKAZE)");
         m_detector=AKAZE::create();

--- a/src/SolARKeypointDetectorOpencv.cpp
+++ b/src/SolARKeypointDetectorOpencv.cpp
@@ -32,12 +32,14 @@ namespace OPENCV {
 static std::map<std::string,KeypointDetectorType> stringToType = {{"AKAZE",KeypointDetectorType::AKAZE},
                                                                   {"AKAZE2",KeypointDetectorType::AKAZE2},
                                                                   {"ORB",KeypointDetectorType::ORB},
-                                                                  {"BRISK",KeypointDetectorType::BRISK}};
+                                                                  {"BRISK",KeypointDetectorType::BRISK},
+                                                                  {"FEATURE_TO_TRACK", KeypointDetectorType::FEATURE_TO_TRACK}};
 
 static std::map<KeypointDetectorType,std::string> typeToString = {{KeypointDetectorType::AKAZE, "AKAZE"},
                                                                   {KeypointDetectorType::AKAZE2,"AKAZE2"},
                                                                   {KeypointDetectorType::ORB,"ORB"},
-                                                                  {KeypointDetectorType::BRISK,"BRISK"}};
+                                                                  {KeypointDetectorType::BRISK,"BRISK"},
+                                                                  {KeypointDetectorType::FEATURE_TO_TRACK,"FEATURE_TO_TRACK"}};
 
 SolARKeypointDetectorOpencv::SolARKeypointDetectorOpencv():ConfigurableBase(xpcf::toUUID<SolARKeypointDetectorOpencv>())
 {
@@ -59,8 +61,16 @@ SolARKeypointDetectorOpencv::~SolARKeypointDetectorOpencv()
 xpcf::XPCFErrorCode SolARKeypointDetectorOpencv::onConfigured()
 {
     LOG_DEBUG(" SolARKeypointDetectorOpencv onConfigured");
-    setType(stringToType.at(m_type));
-    return xpcf::_SUCCESS;
+    if (stringToType.find(m_type) != stringToType.end())
+    {
+        setType(stringToType.at(m_type));
+         return xpcf::_SUCCESS;
+    }
+    else
+    {
+        LOG_WARNING("Keypoint detector of type {} defined in your configuration file does not exist", m_type);
+        return xpcf::_ERROR_NOT_IMPLEMENTED;
+    }
 }
 
 void SolARKeypointDetectorOpencv::setType(KeypointDetectorType type)
@@ -76,6 +86,7 @@ void SolARKeypointDetectorOpencv::setType(KeypointDetectorType type)
         AKAZEUP,
         BRISK,
         BRIEF,
+        FEATURE_TO_TRACK
         */
     m_type=typeToString.at(type);
     switch (type) {
@@ -141,11 +152,22 @@ void SolARKeypointDetectorOpencv::detect(const SRef<Image> &image, std::vector<S
 
     try
     {
-        if(!m_detector){
-            LOG_DEBUG(" detector is initialized with default value : {}", this->m_type)
-            setType(stringToType.at(this->m_type));
+        if (m_type == "FEATURE_TO_TRACK") {
+            std::vector<cv::Point2f> corners;
+            cv::goodFeaturesToTrack(img_1, corners, m_nbDescriptors, 0.008, 3, cv::Mat(), 3);
+            cornerSubPix(img_1, corners, cv::Size(7, 7), Size(-1, -1), cv::TermCriteria(TermCriteria::COUNT | TermCriteria::EPS, 20, 0.03));
+            for (auto it : corners)
+                kpts.push_back(cv::KeyPoint(it, 0.f));
         }
-        m_detector->detect(img_1, kpts, Mat());
+        else {
+            if(!m_detector){
+                LOG_DEBUG(" detector is initialized with default value : {}", this->m_type)
+                setType(stringToType.at(this->m_type));
+            }
+            m_detector->detect(img_1, kpts, Mat());
+            if (m_nbDescriptors >= 0)
+                kptsFilter.retainBest(kpts,m_nbDescriptors);
+        }
     }
     catch (Exception& e)
     {
@@ -153,9 +175,6 @@ void SolARKeypointDetectorOpencv::detect(const SRef<Image> &image, std::vector<S
         LOG_ERROR("{}",e.msg)
         return;
     }
-
-    if (m_nbDescriptors >= 0)
-        kptsFilter.retainBest(kpts,m_nbDescriptors);
 
     for(std::vector<cv::KeyPoint>::iterator itr=kpts.begin();itr!=kpts.end();++itr){
        SRef<Keypoint> kpa = xpcf::utils::make_shared<Keypoint>();

--- a/src/SolARKeypointDetectorRegionOpencv.cpp
+++ b/src/SolARKeypointDetectorRegionOpencv.cpp
@@ -171,7 +171,8 @@ void SolARKeypointDetectorRegionOpencv::detect(const SRef<Image> &image, const s
 			cv::Point2f pt2(contours[(i + 1) % contours.size()]->getX(), contours[(i + 1) % contours.size()]->getY());
 			sumAngles += getAngle(pt1, pt2, ptToCheck);
 		}
-		if (std::fabsf(sumAngles - 2 * CV_PI) < 1e-4)
+		
+		if (std::fabs(sumAngles - 2 * CV_PI) < 1e-4)
 			return true;
 		else
 			return false;

--- a/src/SolARKeypointDetectorRegionOpencv.cpp
+++ b/src/SolARKeypointDetectorRegionOpencv.cpp
@@ -1,0 +1,174 @@
+/**
+ * @copyright Copyright (c) 2017 B-com http://www.b-com.com/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "SolARKeypointDetectorRegionOpencv.h"
+#include "SolAROpenCVHelper.h"
+#include "core/Log.h"
+
+XPCF_DEFINE_FACTORY_CREATE_INSTANCE(SolAR::MODULES::OPENCV::SolARKeypointDetectorRegionOpencv)
+
+namespace xpcf = org::bcom::xpcf;
+
+using namespace cv;
+
+namespace SolAR {
+using namespace datastructure;
+namespace MODULES {
+namespace OPENCV {
+
+static std::map<std::string,KeypointDetectorType> stringToType = {{"AKAZE",KeypointDetectorType::AKAZE},
+                                                                  {"AKAZE2",KeypointDetectorType::AKAZE2},
+                                                                  {"ORB",KeypointDetectorType::ORB},
+                                                                  {"BRISK",KeypointDetectorType::BRISK}};
+
+static std::map<KeypointDetectorType,std::string> typeToString = {{KeypointDetectorType::AKAZE, "AKAZE"},
+                                                                  {KeypointDetectorType::AKAZE2,"AKAZE2"},
+                                                                  {KeypointDetectorType::ORB,"ORB"},
+                                                                  {KeypointDetectorType::BRISK,"BRISK"}};
+
+SolARKeypointDetectorRegionOpencv::SolARKeypointDetectorRegionOpencv():ConfigurableBase(xpcf::toUUID<SolARKeypointDetectorRegionOpencv>())
+{
+    addInterface<api::features::IKeypointDetectorRegion>(this);
+
+    SRef<xpcf::IPropertyMap> params = getPropertyRootNode();
+    params->wrapFloat("imageRatio", m_imageRatio);
+    params->wrapInteger("nbDescriptors", m_nbDescriptors);
+	params->wrapFloat("threshold", m_threshold);
+    params->wrapString("type", m_type);
+    LOG_DEBUG("SolARKeypointDetectorRegionOpencv constructor");
+}
+
+SolARKeypointDetectorRegionOpencv::~SolARKeypointDetectorRegionOpencv()
+{
+    LOG_DEBUG("SolARKeypointDetectorRegionOpencv destructor");
+}
+
+xpcf::XPCFErrorCode SolARKeypointDetectorRegionOpencv::onConfigured()
+{
+    LOG_DEBUG(" SolARKeypointDetectorRegionOpencv onConfigured");
+    setType(stringToType.at(m_type));
+    return xpcf::_SUCCESS;
+}
+
+void SolARKeypointDetectorRegionOpencv::setType(KeypointDetectorType type)
+{
+
+    /*
+     * 	SURF,
+        ORB,
+        SIFT,
+        DAISY,
+        LATCH,
+        AKAZE,
+        AKAZEUP,
+        BRISK,
+        BRIEF,
+        */
+    m_type=typeToString.at(type);
+    switch (type) {
+	case (KeypointDetectorType::AKAZE):
+		LOG_DEBUG("KeypointDetectorImp::setType(AKAZE)");
+		if (m_threshold > 0)
+			m_detector = AKAZE::create(5, 0, 3, m_threshold);
+		else
+			m_detector = AKAZE::create();
+		break;
+	case (KeypointDetectorType::AKAZE2):
+		LOG_DEBUG("KeypointDetectorImp::setType(AKAZE2)");
+		if (m_threshold > 0)
+			m_detector = AKAZE2::create(5, 0, 3, m_threshold);
+		else
+			m_detector = AKAZE2::create();
+		break;
+	case (KeypointDetectorType::ORB):
+        LOG_DEBUG("KeypointDetectorImp::setType(ORB)");
+		if (m_nbDescriptors > 0)
+			m_detector=ORB::create(m_nbDescriptors);
+		else
+			m_detector = ORB::create();
+        break;
+    case (KeypointDetectorType::BRISK):
+        LOG_DEBUG("KeypointDetectorImp::setType(BRISK)");
+		if (m_threshold > 0)
+			m_detector = BRISK::create((int)m_threshold);
+		else
+			m_detector=BRISK::create();
+        break;
+
+
+    default :
+        LOG_DEBUG("KeypointDetectorImp::setType(AKAZE)");
+        m_detector=AKAZE::create();
+        break;
+    }
+}
+
+KeypointDetectorType SolARKeypointDetectorRegionOpencv::getType()
+{
+    return stringToType.at(m_type);
+}
+
+void SolARKeypointDetectorRegionOpencv::detect(const SRef<Image> &image, const std::vector<SRef<Point2Df>>& contours, std::vector<SRef<Keypoint>> &keypoints)
+{
+    std::vector<cv::KeyPoint> kpts;
+
+    // the input image is down-scaled to accelerate the keypoints extraction
+
+    float ratioInv=1.f/m_imageRatio;
+
+    keypoints.clear();
+
+    // instantiation of an opencv image from an input IImage
+    cv::Mat opencvImage = SolAROpenCVHelper::mapToOpenCV(image);
+
+    cv::Mat img_1;
+    cvtColor( opencvImage, img_1, CV_BGR2GRAY );
+    cv::resize(img_1, img_1, Size(img_1.cols*m_imageRatio,img_1.rows*m_imageRatio), 0, 0);
+
+    try
+    {
+        if(!m_detector){
+            LOG_DEBUG(" detector is initialized with default value : {}", this->m_type)
+            setType(stringToType.at(this->m_type));
+        }
+        m_detector->detect(img_1, kpts, Mat());
+    }
+    catch (Exception& e)
+    {
+        LOG_ERROR("Feature : {}", m_detector->getDefaultName())
+        LOG_ERROR("{}",e.msg)
+        return;
+    }
+
+    if (m_nbDescriptors >= 0)
+        kptsFilter.retainBest(kpts,m_nbDescriptors);
+
+    for(std::vector<cv::KeyPoint>::iterator itr=kpts.begin();itr!=kpts.end();++itr){
+       SRef<Keypoint> kpa = xpcf::utils::make_shared<Keypoint>();
+
+        kpa->init((*itr).pt.x*ratioInv,(*itr).pt.y*ratioInv,(*itr).size,(*itr).angle,(*itr).response,(*itr).octave,(*itr).class_id) ;
+        keypoints.push_back(kpa);
+    }
+}
+
+void SolARKeypointDetectorRegionOpencv::detect(const SRef<Image> &image, const SRef<Contour2Df> contours, std::vector<SRef<Keypoint>> &keypoints)
+{
+
+}
+
+}
+}
+}  // end of namespace SolAR

--- a/src/SolARKeypointDetectorRegionOpencv.cpp
+++ b/src/SolARKeypointDetectorRegionOpencv.cpp
@@ -178,7 +178,7 @@ void SolARKeypointDetectorRegionOpencv::detect(const SRef<Image> &image, const s
 	};
 
     for(std::vector<cv::KeyPoint>::iterator itr=kpts.begin();itr!=kpts.end();++itr){
-		if (checkInside(contours, (*itr).pt)) {
+		if (checkInside(contours, (*itr).pt * ratioInv)) {
 			SRef<Keypoint> kpa = xpcf::utils::make_shared<Keypoint>();
 			kpa->init((*itr).pt.x*ratioInv, (*itr).pt.y*ratioInv, (*itr).size, (*itr).angle, (*itr).response, (*itr).octave, (*itr).class_id);
 			keypoints.push_back(kpa);

--- a/src/SolARKeypointDetectorRegionOpencv.cpp
+++ b/src/SolARKeypointDetectorRegionOpencv.cpp
@@ -178,7 +178,8 @@ void SolARKeypointDetectorRegionOpencv::detect(const SRef<Image> &image, const s
 	};
 
     for(std::vector<cv::KeyPoint>::iterator itr=kpts.begin();itr!=kpts.end();++itr){
-		if (checkInside(contours, (*itr).pt * ratioInv)) {
+        Point2f ptToCheck = (*itr).pt * ratioInv;
+        if (checkInside(contours, ptToCheck)) {
 			SRef<Keypoint> kpa = xpcf::utils::make_shared<Keypoint>();
 			kpa->init((*itr).pt.x*ratioInv, (*itr).pt.y*ratioInv, (*itr).size, (*itr).angle, (*itr).response, (*itr).octave, (*itr).class_id);
 			keypoints.push_back(kpa);

--- a/src/SolARKeypointDetectorRegionOpencv.cpp
+++ b/src/SolARKeypointDetectorRegionOpencv.cpp
@@ -164,11 +164,6 @@ void SolARKeypointDetectorRegionOpencv::detect(const SRef<Image> &image, const s
     }
 }
 
-void SolARKeypointDetectorRegionOpencv::detect(const SRef<Image> &image, const SRef<Contour2Df> contours, std::vector<SRef<Keypoint>> &keypoints)
-{
-
-}
-
 }
 }
 }  // end of namespace SolAR

--- a/src/SolARKeypointDetectorRegionOpencv.cpp
+++ b/src/SolARKeypointDetectorRegionOpencv.cpp
@@ -32,12 +32,14 @@ namespace OPENCV {
 static std::map<std::string,KeypointDetectorType> stringToType = {{"AKAZE",KeypointDetectorType::AKAZE},
                                                                   {"AKAZE2",KeypointDetectorType::AKAZE2},
                                                                   {"ORB",KeypointDetectorType::ORB},
-                                                                  {"BRISK",KeypointDetectorType::BRISK}};
+                                                                  {"BRISK",KeypointDetectorType::BRISK},
+                                                                  {"FEATURE_TO_TRACK", KeypointDetectorType::FEATURE_TO_TRACK}};
 
 static std::map<KeypointDetectorType,std::string> typeToString = {{KeypointDetectorType::AKAZE, "AKAZE"},
                                                                   {KeypointDetectorType::AKAZE2,"AKAZE2"},
                                                                   {KeypointDetectorType::ORB,"ORB"},
-                                                                  {KeypointDetectorType::BRISK,"BRISK"}};
+                                                                  {KeypointDetectorType::BRISK,"BRISK"},
+                                                                  {KeypointDetectorType::FEATURE_TO_TRACK,"FEATURE_TO_TRACK"}};
 
 SolARKeypointDetectorRegionOpencv::SolARKeypointDetectorRegionOpencv():ConfigurableBase(xpcf::toUUID<SolARKeypointDetectorRegionOpencv>())
 {
@@ -59,9 +61,16 @@ SolARKeypointDetectorRegionOpencv::~SolARKeypointDetectorRegionOpencv()
 xpcf::XPCFErrorCode SolARKeypointDetectorRegionOpencv::onConfigured()
 {
     LOG_DEBUG(" SolARKeypointDetectorRegionOpencv onConfigured");
-	if (stringToType.find(m_type) != stringToType.end())
-		setType(stringToType.at(m_type));
-    return xpcf::_SUCCESS;
+    if (stringToType.find(m_type) != stringToType.end())
+    {
+        setType(stringToType.at(m_type));
+        return xpcf::_SUCCESS;
+    }
+    else
+    {
+        LOG_WARNING("Keypoint detector of type {} defined in your configuration file does not exist", m_type);
+        return xpcf::_ERROR_NOT_IMPLEMENTED;
+    }
 }
 
 void SolARKeypointDetectorRegionOpencv::setType(KeypointDetectorType type)

--- a/src/SolARMarker2DNaturalImageOpencv.cpp
+++ b/src/SolARMarker2DNaturalImageOpencv.cpp
@@ -86,6 +86,33 @@ namespace OPENCV {
         return SolAROpenCVHelper::convertToSolar(m_ocvImage,img);
     }
 
+    FrameworkReturnCode SolARMarker2DNaturalImageOpencv::getImageCorners(std::vector<SRef<Point2Df>>& imageCorners) const
+    {
+        imageCorners.clear();
+        if (!m_ocvImage.data)
+        {
+            LOG_DEBUG("Marker image has not been loaded");
+            FrameworkReturnCode::_ERROR_;
+        }
+        imageCorners.push_back(xpcf::utils::make_shared<Point2Df>(0.0f, 0.0f));
+        imageCorners.push_back(xpcf::utils::make_shared<Point2Df>(m_ocvImage.size().width, 0.0f));
+        imageCorners.push_back(xpcf::utils::make_shared<Point2Df>(m_ocvImage.size().width,m_ocvImage.size().height));
+        imageCorners.push_back(xpcf::utils::make_shared<Point2Df>(0.0f, m_ocvImage.size().height));
+
+        return FrameworkReturnCode::_SUCCESS;
+    }
+
+    FrameworkReturnCode SolARMarker2DNaturalImageOpencv::getWorldCorners(std::vector<SRef<Point3Df>>& worldCorners) const
+    {
+        worldCorners.clear();
+        worldCorners.push_back(xpcf::utils::make_shared<Point3Df>(-m_size.width/2.0f, -m_size.height/2.0f, 0.0f));
+        worldCorners.push_back(xpcf::utils::make_shared<Point3Df>(m_size.width/2.0f, -m_size.height/2.0f, 0.0f));
+        worldCorners.push_back(xpcf::utils::make_shared<Point3Df>(m_size.width/2.0f, m_size.height/2.0f, 0.0f));
+        worldCorners.push_back(xpcf::utils::make_shared<Point3Df>(-m_size.width/2.0f, m_size.height/2.0f, 0.0f));
+
+        return FrameworkReturnCode::_SUCCESS;
+    }
+
 }
 }
 }  // end of namespace Solar

--- a/src/SolARMarker2DSquaredBinaryOpencv.cpp
+++ b/src/SolARMarker2DSquaredBinaryOpencv.cpp
@@ -85,6 +85,29 @@ namespace OPENCV {
         return FrameworkReturnCode::_SUCCESS;
     }
 
+    FrameworkReturnCode SolARMarker2DSquaredBinaryOpencv::getImageCorners(std::vector<SRef<Point2Df>>& imageCorners) const
+    {
+        imageCorners.clear();
+        float patternSize = (float)m_pattern.getSize();
+
+        imageCorners.push_back(xpcf::utils::make_shared<Point2Df>(-patternSize/2.0f, -patternSize/2.0f));
+        imageCorners.push_back(xpcf::utils::make_shared<Point2Df>(patternSize/2.0f, -patternSize/2.0f));
+        imageCorners.push_back(xpcf::utils::make_shared<Point2Df>(patternSize/2.0f, patternSize/2.0f));
+        imageCorners.push_back(xpcf::utils::make_shared<Point2Df>(-patternSize/2.0f, patternSize/2.0f));
+        return FrameworkReturnCode::_SUCCESS;
+    }
+
+    FrameworkReturnCode SolARMarker2DSquaredBinaryOpencv::getWorldCorners(std::vector<SRef<Point3Df>>& worldCorners) const
+    {
+        worldCorners.clear();
+        worldCorners.push_back(xpcf::utils::make_shared<Point3Df>(-m_size.width/2.0f, -m_size.height/2.0f, 0.0f));
+        worldCorners.push_back(xpcf::utils::make_shared<Point3Df>(m_size.width/2.0f, -m_size.height/2.0f, 0.0f));
+        worldCorners.push_back(xpcf::utils::make_shared<Point3Df>(m_size.width/2.0f, m_size.height/2.0f, 0.0f));
+        worldCorners.push_back(xpcf::utils::make_shared<Point3Df>(-m_size.width/2.0f, m_size.height/2.0f, 0.0f));
+
+        return FrameworkReturnCode::_SUCCESS;
+    }
+
 }
 }
 }

--- a/src/SolARModuleOpencv.cpp
+++ b/src/SolARModuleOpencv.cpp
@@ -43,6 +43,7 @@
 #include "SolARImageLoaderOpencv.h"
 #include "SolARImageViewerOpencv.h"
 #include "SolARKeypointDetectorOpencv.h"
+#include "SolAROpticalFlowPyrLKOpencv.h"
 #include "SolARMarker2DNaturalImageOpencv.h"
 #include "SolARMarker2DSquaredBinaryOpencv.h"
 #include "SolARPerspectiveControllerOpencv.h"
@@ -171,6 +172,10 @@ extern "C" XPCF_MODULEHOOKS_API xpcf::XPCFErrorCode XPCF_getComponent(const boos
     }
     if (errCode != xpcf::XPCFErrorCode::_SUCCESS)
     {
+        errCode = xpcf::tryCreateComponent<SolAR::MODULES::OPENCV::SolAROpticalFlowPyrLKOpencv>(componentUUID,interfaceRef);
+    }
+    if (errCode != xpcf::XPCFErrorCode::_SUCCESS)
+    {
         errCode = xpcf::tryCreateComponent<SolAR::MODULES::OPENCV::SolARMarker2DNaturalImageOpencv>(componentUUID,interfaceRef);
     }
     if (errCode != xpcf::XPCFErrorCode::_SUCCESS)
@@ -252,6 +257,7 @@ XPCF_ADD_COMPONENT(SolAR::MODULES::OPENCV::SolARImageFilterErodeOpencv)
 XPCF_ADD_COMPONENT(SolAR::MODULES::OPENCV::SolARImageLoaderOpencv)
 XPCF_ADD_COMPONENT(SolAR::MODULES::OPENCV::SolARImageViewerOpencv)
 XPCF_ADD_COMPONENT(SolAR::MODULES::OPENCV::SolARKeypointDetectorOpencv)
+XPCF_ADD_COMPONENT(SolAR::MODULES::OPENCV::SolAROpticalFlowPyrLKOpencv)
 XPCF_ADD_COMPONENT(SolAR::MODULES::OPENCV::SolARMarker2DNaturalImageOpencv)
 XPCF_ADD_COMPONENT(SolAR::MODULES::OPENCV::SolARMarker2DSquaredBinaryOpencv)
 XPCF_ADD_COMPONENT(SolAR::MODULES::OPENCV::SolARPerspectiveControllerOpencv)

--- a/src/SolARModuleOpencv.cpp
+++ b/src/SolARModuleOpencv.cpp
@@ -47,6 +47,7 @@
 #include "SolARMarker2DNaturalImageOpencv.h"
 #include "SolARMarker2DSquaredBinaryOpencv.h"
 #include "SolARPerspectiveControllerOpencv.h"
+#include "SolARPoseEstimationPlanarPointsOpencv.h"
 #include "SolARPoseEstimationPnpEPFL.h"
 #include "SolARPoseEstimationPnpOpencv.h"
 #include "SolARPoseEstimationSACPnpOpencv.h"
@@ -188,6 +189,10 @@ extern "C" XPCF_MODULEHOOKS_API xpcf::XPCFErrorCode XPCF_getComponent(const boos
     }
     if (errCode != xpcf::XPCFErrorCode::_SUCCESS)
     {
+        errCode = xpcf::tryCreateComponent<SolAR::MODULES::OPENCV::SolARPoseEstimationPlanarPointsOpencv>(componentUUID,interfaceRef);
+    }
+    if (errCode != xpcf::XPCFErrorCode::_SUCCESS)
+    {
         errCode = xpcf::tryCreateComponent<SolAR::MODULES::OPENCV::SolARPoseEstimationPnpOpencv>(componentUUID,interfaceRef);
     }
     if (errCode != xpcf::XPCFErrorCode::_SUCCESS)
@@ -261,6 +266,7 @@ XPCF_ADD_COMPONENT(SolAR::MODULES::OPENCV::SolAROpticalFlowPyrLKOpencv)
 XPCF_ADD_COMPONENT(SolAR::MODULES::OPENCV::SolARMarker2DNaturalImageOpencv)
 XPCF_ADD_COMPONENT(SolAR::MODULES::OPENCV::SolARMarker2DSquaredBinaryOpencv)
 XPCF_ADD_COMPONENT(SolAR::MODULES::OPENCV::SolARPerspectiveControllerOpencv)
+XPCF_ADD_COMPONENT(SolAR::MODULES::OPENCV::SolARPoseEstimationPlanarPointsOpencv)
 XPCF_ADD_COMPONENT(SolAR::MODULES::OPENCV::SolARPoseEstimationPnpEPFL)
 XPCF_ADD_COMPONENT(SolAR::MODULES::OPENCV::SolARPoseEstimationPnpOpencv)
 XPCF_ADD_COMPONENT(SolAR::MODULES::OPENCV::SolARPoseEstimationSACPnpOpencv)

--- a/src/SolARModuleOpencv.cpp
+++ b/src/SolARModuleOpencv.cpp
@@ -43,10 +43,13 @@
 #include "SolARImageLoaderOpencv.h"
 #include "SolARImageViewerOpencv.h"
 #include "SolARKeypointDetectorOpencv.h"
+#include "SolARKeypointDetectorRegionOpencv.h"
 #include "SolAROpticalFlowPyrLKOpencv.h"
 #include "SolARMarker2DNaturalImageOpencv.h"
 #include "SolARMarker2DSquaredBinaryOpencv.h"
 #include "SolARPerspectiveControllerOpencv.h"
+#include "SolARProjectOpencv.h"
+#include "SolARUnprojectPlanarPointsOpencv.h"
 #include "SolARPoseEstimationPlanarPointsOpencv.h"
 #include "SolARPoseEstimationPnpEPFL.h"
 #include "SolARPoseEstimationPnpOpencv.h"
@@ -173,6 +176,10 @@ extern "C" XPCF_MODULEHOOKS_API xpcf::XPCFErrorCode XPCF_getComponent(const boos
     }
     if (errCode != xpcf::XPCFErrorCode::_SUCCESS)
     {
+        errCode = xpcf::tryCreateComponent<SolAR::MODULES::OPENCV::SolARKeypointDetectorRegionOpencv>(componentUUID,interfaceRef);
+    }
+    if (errCode != xpcf::XPCFErrorCode::_SUCCESS)
+    {
         errCode = xpcf::tryCreateComponent<SolAR::MODULES::OPENCV::SolAROpticalFlowPyrLKOpencv>(componentUUID,interfaceRef);
     }
     if (errCode != xpcf::XPCFErrorCode::_SUCCESS)
@@ -186,6 +193,14 @@ extern "C" XPCF_MODULEHOOKS_API xpcf::XPCFErrorCode XPCF_getComponent(const boos
     if (errCode != xpcf::XPCFErrorCode::_SUCCESS)
     {
         errCode = xpcf::tryCreateComponent<SolAR::MODULES::OPENCV::SolARPerspectiveControllerOpencv>(componentUUID,interfaceRef);
+    }
+    if (errCode != xpcf::XPCFErrorCode::_SUCCESS)
+    {
+        errCode = xpcf::tryCreateComponent<SolAR::MODULES::OPENCV::SolARProjectOpencv>(componentUUID,interfaceRef);
+    }
+    if (errCode != xpcf::XPCFErrorCode::_SUCCESS)
+    {
+        errCode = xpcf::tryCreateComponent<SolAR::MODULES::OPENCV::SolARUnprojectPlanarPointsOpencv>(componentUUID,interfaceRef);
     }
     if (errCode != xpcf::XPCFErrorCode::_SUCCESS)
     {
@@ -262,10 +277,13 @@ XPCF_ADD_COMPONENT(SolAR::MODULES::OPENCV::SolARImageFilterErodeOpencv)
 XPCF_ADD_COMPONENT(SolAR::MODULES::OPENCV::SolARImageLoaderOpencv)
 XPCF_ADD_COMPONENT(SolAR::MODULES::OPENCV::SolARImageViewerOpencv)
 XPCF_ADD_COMPONENT(SolAR::MODULES::OPENCV::SolARKeypointDetectorOpencv)
+XPCF_ADD_COMPONENT(SolAR::MODULES::OPENCV::SolARKeypointDetectorRegionOpencv)
 XPCF_ADD_COMPONENT(SolAR::MODULES::OPENCV::SolAROpticalFlowPyrLKOpencv)
 XPCF_ADD_COMPONENT(SolAR::MODULES::OPENCV::SolARMarker2DNaturalImageOpencv)
 XPCF_ADD_COMPONENT(SolAR::MODULES::OPENCV::SolARMarker2DSquaredBinaryOpencv)
 XPCF_ADD_COMPONENT(SolAR::MODULES::OPENCV::SolARPerspectiveControllerOpencv)
+XPCF_ADD_COMPONENT(SolAR::MODULES::OPENCV::SolARProjectOpencv)
+XPCF_ADD_COMPONENT(SolAR::MODULES::OPENCV::SolARUnprojectPlanarPointsOpencv)
 XPCF_ADD_COMPONENT(SolAR::MODULES::OPENCV::SolARPoseEstimationPlanarPointsOpencv)
 XPCF_ADD_COMPONENT(SolAR::MODULES::OPENCV::SolARPoseEstimationPnpEPFL)
 XPCF_ADD_COMPONENT(SolAR::MODULES::OPENCV::SolARPoseEstimationPnpOpencv)

--- a/src/SolAROpenCVHelper.cpp
+++ b/src/SolAROpenCVHelper.cpp
@@ -79,7 +79,7 @@ std::vector<cv::Point2i> SolAROpenCVHelper::convertToOpenCV (const Contour2Di &c
     std::vector<cv::Point2i> output;
     for (int i = 0; i < contour.size(); i++)
     {
-        output.push_back(cv::Point2i(contour[i][0], contour[i][1]));
+        output.push_back(cv::Point2i(contour[i]->getX(), contour[i]->getY()));
     }
     return output;
 }
@@ -89,7 +89,7 @@ std::vector<cv::Point2f> SolAROpenCVHelper::convertToOpenCV (const Contour2Df &c
     std::vector<cv::Point2f> output;
     for (int i = 0; i < contour.size(); i++)
     {
-        output.push_back(cv::Point2f(contour[i][0], contour[i][1]));
+        output.push_back(cv::Point2f(contour[i]->getX(), contour[i]->getY()));
     }
     return output;
 }

--- a/src/SolAROpticalFlowPyrLKOpencv.cpp
+++ b/src/SolAROpticalFlowPyrLKOpencv.cpp
@@ -1,0 +1,135 @@
+/**
+ * @copyright Copyright (c) 2017 B-com http://www.b-com.com/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "SolAROpticalFlowPyrLKOpencv.h"
+#include "SolAROpenCVHelper.h"
+#include "core/Log.h"
+
+namespace xpcf  = org::bcom::xpcf;
+
+XPCF_DEFINE_FACTORY_CREATE_INSTANCE(SolAR::MODULES::OPENCV::SolAROpticalFlowPyrLKOpencv)
+
+namespace SolAR {
+using namespace datastructure;
+using namespace api::tracking;
+namespace MODULES {
+namespace OPENCV {
+
+SolAROpticalFlowPyrLKOpencv::SolAROpticalFlowPyrLKOpencv():ConfigurableBase(xpcf::toUUID<SolAROpticalFlowPyrLKOpencv>())
+{
+    addInterface<IOpticalFlowEstimator>(this);
+    SRef<xpcf::IPropertyMap> params = getPropertyRootNode();
+    params->wrapInteger("searchWinWidth", m_searchWinWidth);
+    params->wrapInteger("searchWinHeight", m_searchWinHeight);
+    params->wrapInteger("maxLevel", m_maxLevel);
+    params->wrapDouble("minEigenThreshold", m_minEigenThreshold);
+    params->wrapInteger("maxSearchIterations", m_maxSearchIterations);
+    params->wrapFloat("searchWindowAccuracy",m_searchWindowAccuracy);
+
+    LOG_DEBUG(" SolAROpticalFlowPyrLKOpencv constructor")
+}
+
+SolAROpticalFlowPyrLKOpencv::~SolAROpticalFlowPyrLKOpencv()
+{
+    LOG_DEBUG(" SolAROpticalFlowPyrLKOpencv destructor")
+}
+
+template <class T> std::vector<cv::Point2f> fillcvpoints(const std::vector<SRef<T>> & points)
+{
+
+}
+
+template <>
+inline std::vector<cv::Point2f> fillcvpoints(const std::vector<SRef<Point2Df>> & points)
+{
+
+    std::vector<cv::Point2f> cv_points;
+    for (auto point : points)
+        cv_points.push_back(cv::Point2f(point->getX(), point->getY()));
+    return cv_points;
+}
+
+template <>
+inline std::vector<cv::Point2f> fillcvpoints(const std::vector<SRef<Keypoint>> & points)
+{
+    std::vector<cv::Point2f> cv_points;
+    for (auto point : points)
+        cv_points.push_back(cv::Point2f(point->getX(), point->getY()));
+    return cv_points;
+}
+
+FrameworkReturnCode SolAROpticalFlowPyrLKOpencv::estimate(
+                const SRef<Image> previousImage,
+                const SRef<Image> currentImage,
+                const std::vector<SRef<Keypoint>> & pointsToTrack,
+                std::vector<SRef<Point2Df>> & trackedPoints,
+                std::vector<unsigned char> & status,
+                std::vector<float> & error)
+{
+    std::vector<cv::Point2f> cv_points = fillcvpoints (pointsToTrack);
+    return estimate (previousImage, currentImage, cv_points, trackedPoints, status, error);
+}
+
+FrameworkReturnCode SolAROpticalFlowPyrLKOpencv::estimate(
+                const SRef<Image> previousImage,
+                const SRef<Image> currentImage,
+                const std::vector<SRef<Point2Df>> & pointsToTrack,
+                std::vector<SRef<Point2Df>> & trackedPoints,
+                std::vector<unsigned char> & status,
+                std::vector<float> & error)
+{
+    std::vector<cv::Point2f> cv_points = fillcvpoints (pointsToTrack);
+    return estimate (previousImage, currentImage, cv_points, trackedPoints, status, error);
+}
+
+FrameworkReturnCode SolAROpticalFlowPyrLKOpencv::estimate(const SRef<Image> previousImage,
+                                                          const SRef<Image> currentImage,
+                                                          const std::vector<cv::Point2f> & pointsToTrack,
+                                                          std::vector<SRef<Point2Df>> & trackedPoints,
+                                                          std::vector<unsigned char> & status,
+                                                          std::vector<float> & error)
+{
+    cv::Mat previousFrame, currentFrame;
+    if (previousImage->getImageLayout() == Image::ImageLayout::LAYOUT_GREY)
+        previousFrame = SolAR::MODULES::OPENCV::SolAROpenCVHelper::mapToOpenCV(previousImage);
+    else {
+        cv::Mat tempPreviousFrame = SolAR::MODULES::OPENCV::SolAROpenCVHelper::mapToOpenCV(previousImage);
+         cv::cvtColor(tempPreviousFrame, previousFrame, cv::COLOR_BGR2GRAY);
+    }
+
+    if (currentImage->getImageLayout() == Image::ImageLayout::LAYOUT_GREY)
+        currentFrame = SolAR::MODULES::OPENCV::SolAROpenCVHelper::mapToOpenCV(currentImage);
+    else {
+        cv::Mat tempCurrentFrame = SolAR::MODULES::OPENCV::SolAROpenCVHelper::mapToOpenCV(currentImage);
+         cv::cvtColor(tempCurrentFrame, currentFrame, cv::COLOR_BGR2GRAY);
+    }
+
+    std::vector<cv::Point2f> cv_trackedPoints;
+
+    cv::TermCriteria termcrit(cv::TermCriteria::COUNT | cv::TermCriteria::EPS, m_maxSearchIterations, m_searchWindowAccuracy);
+    int flags = m_minEigenThreshold <=0 ? 0 : cv::OPTFLOW_LK_GET_MIN_EIGENVALS;
+    cv::calcOpticalFlowPyrLK(previousFrame, currentFrame, pointsToTrack, cv_trackedPoints, status, error, cv::Size(m_searchWinWidth, m_searchWinHeight), m_maxLevel, termcrit, flags, m_minEigenThreshold);
+
+    trackedPoints.clear();
+    for (int i = 0; i < cv_trackedPoints.size(); i++)
+        trackedPoints.push_back(xpcf::utils::make_shared<Point2Df>(cv_trackedPoints[i].x, cv_trackedPoints[i].y));
+
+    return FrameworkReturnCode::_SUCCESS;
+}
+
+}
+}
+}  // end of namespace SolAR

--- a/src/SolARPerspectiveControllerOpencv.cpp
+++ b/src/SolARPerspectiveControllerOpencv.cpp
@@ -53,7 +53,7 @@ namespace OPENCV {
         {
             for(unsigned int j =0; j < 4; ++j)
             {
-               points.push_back(cv::Point2f((*contour)[j][0],(*contour)[j][1]));
+               points.push_back(cv::Point2f((*contour)[j]->getX(),(*contour)[j]->getY()));
             }
                 // Find the perspective transformation that brings current marker to rectangular form
             cv::Mat markerTransform = cv::getPerspectiveTransform(points, markerCorners2D);
@@ -102,7 +102,7 @@ namespace OPENCV {
             {
                 for(unsigned int j =0; j < 4; ++j)
                 {
-                   points.push_back(cv::Point2f((*(contours[i]))[j][0],(*(contours[i]))[j][1]));
+                   points.push_back(cv::Point2f((*(contours[i]))[j]->getX(),(*(contours[i]))[j]->getY()));
                 }
                     // Find the perspective transformation that brings current marker to rectangular form
                 cv::Mat markerTransform = cv::getPerspectiveTransform(points, markerCorners2D);

--- a/src/SolARPoseEstimationPlanarPointsOpencv.cpp
+++ b/src/SolARPoseEstimationPlanarPointsOpencv.cpp
@@ -96,25 +96,28 @@ FrameworkReturnCode SolARPoseEstimationPlanarPointsOpencv::estimate(const std::v
     }
 
     // Refine the homography matrix only with inliers
-    oHw = cv::findHomography(worldCVPoints, correctedImageCVPoints);
+    oHw = cv::findHomography(tmp_cvWorldPoints, tmp_cvImagePoints);
 
     // Normalization to ensure that ||c1|| = 1
     double norm = sqrt(oHw.at<double>(0, 0) * oHw.at<double>(0, 0) + oHw.at<double>(1, 0) * oHw.at<double>(1, 0) + oHw.at<double>(2, 0) * oHw.at<double>(2, 0));
     oHw /= norm;
 
+    // 3rd column = cross product between first and second columns
+    oHw.col(2)= oHw.col(0).cross(oHw.col(1));
+
     for (int row = 0; row<3; row++){
-        for (int col = 0; col<2; col++){
+        for (int col = 0; col<3; col++){
             pose(row,col) = (float)(oHw.at<double>(row, col));
         }
-        pose(row,2) = (float)(oHw.at<double>(row,0) * oHw.at<double>(row,1));
         pose(row,3) = (float)(oHw.at<double>(row,2));
     }
+
     pose(3,0)  = 0.0;
     pose(3,1)  = 0.0;
     pose(3,2)  = 0.0;
     pose(3,3)  = 1.0;
 
-    //pose = pose.inverse();
+    pose = pose.inverse();
 
     return FrameworkReturnCode::_SUCCESS;
 }

--- a/src/SolARPoseEstimationPlanarPointsOpencv.cpp
+++ b/src/SolARPoseEstimationPlanarPointsOpencv.cpp
@@ -1,0 +1,142 @@
+/**
+ * @copyright Copyright (c) 2017 B-com http://www.b-com.com/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "SolARPoseEstimationPlanarPointsOpencv.h"
+#include "SolAROpenCVHelper.h"
+#include "core/Log.h"
+#include "opencv2/calib3d/calib3d.hpp"
+#include <opencv2/imgproc.hpp>
+
+XPCF_DEFINE_FACTORY_CREATE_INSTANCE(SolAR::MODULES::OPENCV::SolARPoseEstimationPlanarPointsOpencv);
+
+namespace xpcf  = org::bcom::xpcf;
+
+namespace SolAR {
+using namespace datastructure;
+namespace MODULES {
+namespace OPENCV {
+
+SolARPoseEstimationPlanarPointsOpencv::SolARPoseEstimationPlanarPointsOpencv():ConfigurableBase(xpcf::toUUID<SolARPoseEstimationPlanarPointsOpencv>())
+{
+    addInterface<api::solver::pose::I3DTransformSACFinderFrom2D3D>(this);
+    SRef<xpcf::IPropertyMap> params = getPropertyRootNode();
+    params->wrapInteger("minNbInliers", m_minNbInliers);
+    params->wrapFloat("reprojErrorThreshold", m_reprojErrorThreshold);
+
+    m_camMatrix.create(3, 3, CV_32FC1);
+    m_camDistorsion.create(5, 1, CV_32FC1);
+
+    LOG_DEBUG(" SolARPoseEstimationOpencv constructor");
+}
+
+SolARPoseEstimationPlanarPointsOpencv::~SolARPoseEstimationPlanarPointsOpencv(){
+
+}
+
+FrameworkReturnCode SolARPoseEstimationPlanarPointsOpencv::estimate(const std::vector<SRef<Point2Df>> & imagePoints,
+                                                                    const std::vector<SRef<Point3Df>> & worldPoints,
+                                                                    std::vector<SRef<Point2Df>> &imagePoints_inlier,
+                                                                    std::vector<SRef<Point3Df>> &worldPoints_inlier,
+                                                                    Transform3Df & pose,
+                                                                    const Transform3Df initialPose) {
+
+    std::vector<cv::Point2f> imageCVPoints;
+    std::vector<cv::Point2f> worldCVPoints;
+    std::vector<cv::Point2f> correctedImageCVPoints;
+
+    if (worldPoints.size()!=imagePoints.size() || worldPoints.size()< 4 ){
+        LOG_WARNING("world/image points must be valid ( equal and > to 4)");
+        return FrameworkReturnCode::_ERROR_  ; // vector of 2D and 3D points must have same size
+    }
+
+    for (int i=0;i<imagePoints.size();++i) {
+
+        Point2Df point2D = *(imagePoints.at(i));
+        Point3Df point3D = *(worldPoints.at(i));
+        imageCVPoints.push_back(cv::Point2f(point2D.getX(), point2D.getY()));
+        worldCVPoints.push_back(cv::Point2f(point3D.getX(), point3D.getY()));
+    }
+
+    // undistort 2D points
+    cv::undistortPoints(imageCVPoints, correctedImageCVPoints, m_camMatrix, m_camDistorsion);
+
+    // Compute the homography matrix with ransac
+    cv::Mat status;
+    cv::Mat oHw = findHomography(worldCVPoints, correctedImageCVPoints, cv::RANSAC, m_reprojErrorThreshold, status);
+
+    imagePoints_inlier.clear();
+    worldPoints_inlier.clear();
+    std::vector<cv::Point2f> tmp_cvImagePoints, tmp_cvWorldPoints;
+    for (int i = 0; i < status.rows; ++i)
+    {
+        if (status.at<uchar>(i, 0) == 1)
+        {
+            imagePoints_inlier.push_back(imagePoints[i]);
+            worldPoints_inlier.push_back(worldPoints[i]);
+            tmp_cvImagePoints.push_back(correctedImageCVPoints[i]);
+            tmp_cvWorldPoints.push_back(worldCVPoints[i]);
+        }
+    }
+
+    if (imagePoints_inlier.size() < m_minNbInliers){
+        return FrameworkReturnCode::_ERROR_;
+    }
+
+    // Refine the homography matrix only with inliers
+    oHw = cv::findHomography(worldCVPoints, correctedImageCVPoints);
+
+    // Normalization to ensure that ||c1|| = 1
+    double norm = sqrt(oHw.at<double>(0, 0) * oHw.at<double>(0, 0) + oHw.at<double>(1, 0) * oHw.at<double>(1, 0) + oHw.at<double>(2, 0) * oHw.at<double>(2, 0));
+    oHw /= norm;
+
+    for (int row = 0; row<3; row++){
+        for (int col = 0; col<2; col++){
+            pose(row,col) = (float)(oHw.at<double>(row, col));
+        }
+        pose(row,2) = (float)(oHw.at<double>(row,0) * oHw.at<double>(row,1));
+        pose(row,3) = (float)(oHw.at<double>(row,2));
+    }
+    pose(3,0)  = 0.0;
+    pose(3,1)  = 0.0;
+    pose(3,2)  = 0.0;
+    pose(3,3)  = 1.0;
+
+    //pose = pose.inverse();
+
+    return FrameworkReturnCode::_SUCCESS;
+}
+void SolARPoseEstimationPlanarPointsOpencv::setCameraParameters(const CamCalibration & intrinsicParams, const CamDistortion & distorsionParams) {
+
+    this->m_camDistorsion.at<float>(0, 0)  = distorsionParams(0);
+    this->m_camDistorsion.at<float>(1, 0)  = distorsionParams(1);
+    this->m_camDistorsion.at<float>(2, 0)  = distorsionParams(2);
+    this->m_camDistorsion.at<float>(3, 0)  = distorsionParams(3);
+    this->m_camDistorsion.at<float>(4, 0)  = distorsionParams(4);
+
+    this->m_camMatrix.at<float>(0, 0) = intrinsicParams(0,0);
+    this->m_camMatrix.at<float>(0, 1) = intrinsicParams(0,1);
+    this->m_camMatrix.at<float>(0, 2) = intrinsicParams(0,2);
+    this->m_camMatrix.at<float>(1, 0) = intrinsicParams(1,0);
+    this->m_camMatrix.at<float>(1, 1) = intrinsicParams(1,1);
+    this->m_camMatrix.at<float>(1, 2) = intrinsicParams(1,2);
+    this->m_camMatrix.at<float>(2, 0) = intrinsicParams(2,0);
+    this->m_camMatrix.at<float>(2, 1) = intrinsicParams(2,1);
+    this->m_camMatrix.at<float>(2, 2) = intrinsicParams(2,2);
+}
+
+}
+}
+}

--- a/src/SolARPoseEstimationPlanarPointsOpencv.cpp
+++ b/src/SolARPoseEstimationPlanarPointsOpencv.cpp
@@ -102,14 +102,18 @@ FrameworkReturnCode SolARPoseEstimationPlanarPointsOpencv::estimate(const std::v
     double norm = sqrt(oHw.at<double>(0, 0) * oHw.at<double>(0, 0) + oHw.at<double>(1, 0) * oHw.at<double>(1, 0) + oHw.at<double>(2, 0) * oHw.at<double>(2, 0));
     oHw /= norm;
 
-    // 3rd column = cross product between first and second columns
-    oHw.col(2)= oHw.col(0).cross(oHw.col(1));
-
     for (int row = 0; row<3; row++){
-        for (int col = 0; col<3; col++){
+        for (int col = 0; col<2; col++){
             pose(row,col) = (float)(oHw.at<double>(row, col));
         }
         pose(row,3) = (float)(oHw.at<double>(row,2));
+    }
+
+    // 3rd column of pose matrix = cross product between first and second columns of homography
+    oHw.col(2)= oHw.col(0).cross(oHw.col(1));
+
+    for (int row = 0; row<3; row++){
+        pose(row,2) = (float)(oHw.at<double>(row, 2));
     }
 
     pose(3,0)  = 0.0;

--- a/src/SolARPoseEstimationPlanarPointsOpencv.cpp
+++ b/src/SolARPoseEstimationPlanarPointsOpencv.cpp
@@ -110,10 +110,10 @@ FrameworkReturnCode SolARPoseEstimationPlanarPointsOpencv::estimate(const std::v
     }
 
     // 3rd column of pose matrix = cross product between first and second columns of homography
-    oHw.col(2)= oHw.col(0).cross(oHw.col(1));
+    cv::Mat c3 = oHw.col(0).cross(oHw.col(1));
 
     for (int row = 0; row<3; row++){
-        pose(row,2) = (float)(oHw.at<double>(row, 2));
+        pose(row,2) = (float)(c3.at<double>(row, 0));
     }
 
     pose(3,0)  = 0.0;

--- a/src/SolARPoseEstimationPnpOpencv.cpp
+++ b/src/SolARPoseEstimationPnpOpencv.cpp
@@ -77,7 +77,7 @@ FrameworkReturnCode SolARPoseEstimationPnpOpencv::estimate( const std::vector<SR
     // If initialPose is not Identity, set the useExtrinsicGuess to true. Warning, does not work on coplanar points
     if (!initialPoseInverse.isApprox(Transform3Df::Identity())){
 
-        int type = inferOpenCVType<float>(); // typeid ??
+        int type = SolAROpenCVHelper::inferOpenCVType<float>();
         raux = cv::Mat(3,3,type,(void *)initialPoseInverse.rotation().data());
         taux = cv::Mat(3,1,type,(void *)initialPoseInverse.translation().data());
         

--- a/src/SolARPoseEstimationPnpOpencv.cpp
+++ b/src/SolARPoseEstimationPnpOpencv.cpp
@@ -93,14 +93,11 @@ FrameworkReturnCode SolARPoseEstimationPnpOpencv::estimate( const std::vector<SR
     cv::Mat_<float> rotMat(3, 3);
     cv::Rodrigues(Rvec, rotMat);
 
-    Eigen::Matrix3f Rpose;
-    Eigen::Vector3f Tpose;
-
-    for (int col = 0; col<3; col++){
-          for (int row = 0; row<3; row++){
-                  pose(row,col) = rotMat(row, col);
-          }
-         pose(col,3) = Tvec(col);
+    for (int row = 0; row<3; row++){
+        for (int col = 0; col<3; col++){
+            pose(row,col) = rotMat(row, col);
+         }
+         pose(row,3) = Tvec(row);
     }
     pose(3,0)  = 0.0;
     pose(3,1)  = 0.0;

--- a/src/SolARPoseEstimationSACPnpOpencv.cpp
+++ b/src/SolARPoseEstimationSACPnpOpencv.cpp
@@ -78,7 +78,7 @@ FrameworkReturnCode SolARPoseEstimationSACPnpOpencv::estimate( const std::vector
      // If initialPose is not Identity, set the useExtrinsicGuess to true. Warning, does not work on coplanar points
      if (!initialPoseInverse.isApprox(Transform3Df::Identity()))
      {
-         int type = inferOpenCVType<float>(); // typeid ??
+         int type = SolAROpenCVHelper::inferOpenCVType<float>();
          raux = cv::Mat(3,3,type,(void *)initialPoseInverse.rotation().data());
          taux = cv::Mat(3,1,type,(void *)initialPoseInverse.translation().data());
 

--- a/src/SolARPoseEstimationSACPnpOpencv.cpp
+++ b/src/SolARPoseEstimationSACPnpOpencv.cpp
@@ -121,11 +121,11 @@ FrameworkReturnCode SolARPoseEstimationSACPnpOpencv::estimate( const std::vector
     Eigen::Matrix3f Rpose;
     Eigen::Vector3f Tpose;
 
-    for (int col = 0; col<3; col++){
-          for (int row = 0; row<3; row++){
-                  pose(row,col) = rotMat(row, col);
-          }
-         pose(col,3) = Tvec(col);
+    for (int row = 0; row<3; row++){
+        for (int col = 0; col<3; col++){
+            pose(row,col) = rotMat(row, col);
+         }
+         pose(row,3) = Tvec(row);
     }
     pose(3,0)  = 0.0;
     pose(3,1)  = 0.0;

--- a/src/SolARProjectOpencv.cpp
+++ b/src/SolARProjectOpencv.cpp
@@ -50,8 +50,8 @@ FrameworkReturnCode SolARProjectOpencv::project(const std::vector<SRef<Point3Df>
 	Transform3Df poseInv = pose.inverse();
 
 	cv::Mat rotMat, rvec;
-	rotMat = cv::Mat(3, 3, CV_32F, (void *)poseInv.rotation().data());
-	cv::Mat tvec(3, 1, CV_32F);
+	rotMat = cv::Mat(3, 3, SolAROpenCVHelper::inferOpenCVType<float>(), (void *)poseInv.rotation().data());
+	cv::Mat tvec(3, 1, SolAROpenCVHelper::inferOpenCVType<float>());
 	tvec.at<float>(0, 0) = poseInv(0, 3);
 	tvec.at<float>(1, 0) = poseInv(1, 3);
 	tvec.at<float>(2, 0) = poseInv(2, 3);

--- a/src/SolARProjectOpencv.cpp
+++ b/src/SolARProjectOpencv.cpp
@@ -47,12 +47,15 @@ FrameworkReturnCode SolARProjectOpencv::project(const std::vector<SRef<Point3Df>
     std::vector<cv::Point3f> cvWorldPoints;
     std::vector<cv::Point2f> cvImagePoints;
 
-    cv::Mat rvec;
-    cv::Mat_<float> tvec;
+	Transform3Df poseInv = pose.inverse();
 
-    int type = inferOpenCVType<float>(); // typeid ??
-    rvec = cv::Mat(3,3,type,(void *)pose.rotation().data());
-    tvec = cv::Mat(3,1,type,(void *)pose.translation().data());
+	cv::Mat rotMat, rvec;
+	rotMat = cv::Mat(3, 3, CV_32F, (void *)poseInv.rotation().data());
+	cv::Mat tvec(3, 1, CV_32F);
+	tvec.at<float>(0, 0) = poseInv(0, 3);
+	tvec.at<float>(1, 0) = poseInv(1, 3);
+	tvec.at<float>(2, 0) = poseInv(2, 3);
+	cv::Rodrigues(rotMat, rvec);
 
     for (auto point : inputPoints)
         cvWorldPoints.push_back(cv::Point3f(point->getX(), point->getY(), point->getZ()));

--- a/src/SolARProjectOpencv.cpp
+++ b/src/SolARProjectOpencv.cpp
@@ -42,7 +42,7 @@ SolARProjectOpencv::~SolARProjectOpencv(){
 
 }
 
-FrameworkReturnCode SolARProjectOpencv::project(const std::vector<SRef<Point3Df>> & inputPoints, const Transform3Df& pose, std::vector<SRef<Point2Df>> & imagePoints)
+FrameworkReturnCode SolARProjectOpencv::project(const std::vector<SRef<Point3Df>> & inputPoints, std::vector<SRef<Point2Df>> & imagePoints, const Transform3Df& pose)
 {
     std::vector<cv::Point3f> cvWorldPoints;
     std::vector<cv::Point2f> cvImagePoints;

--- a/src/SolARProjectOpencv.cpp
+++ b/src/SolARProjectOpencv.cpp
@@ -44,6 +44,24 @@ SolARProjectOpencv::~SolARProjectOpencv(){
 
 FrameworkReturnCode SolARProjectOpencv::project(const std::vector<SRef<Point3Df>> & inputPoints, const Transform3Df& pose, std::vector<SRef<Point2Df>> & imagePoints)
 {
+    std::vector<cv::Point3f> cvWorldPoints;
+    std::vector<cv::Point2f> cvImagePoints;
+
+    cv::Mat rvec;
+    cv::Mat_<float> tvec;
+
+    int type = inferOpenCVType<float>(); // typeid ??
+    rvec = cv::Mat(3,3,type,(void *)pose.rotation().data());
+    tvec = cv::Mat(3,1,type,(void *)pose.translation().data());
+
+    for (auto point : inputPoints)
+        cvWorldPoints.push_back(cv::Point3f(point->getX(), point->getY(), point->getZ()));
+
+    cv::projectPoints(cvWorldPoints, rvec, tvec, m_camMatrix, m_camDistorsion, cvImagePoints);
+
+    imagePoints.clear();
+    for (auto cvPoint : cvImagePoints)
+        imagePoints.push_back(xpcf::utils::make_shared<Point2Df>((float)cvPoint.x, (float)cvPoint.y));
 
     return FrameworkReturnCode::_SUCCESS;
 }

--- a/src/SolARProjectOpencv.cpp
+++ b/src/SolARProjectOpencv.cpp
@@ -1,0 +1,71 @@
+/**
+ * @copyright Copyright (c) 2017 B-com http://www.b-com.com/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "SolARProjectOpencv.h"
+#include "SolAROpenCVHelper.h"
+#include "core/Log.h"
+#include "opencv2/calib3d/calib3d.hpp"
+
+XPCF_DEFINE_FACTORY_CREATE_INSTANCE(SolAR::MODULES::OPENCV::SolARProjectOpencv);
+
+namespace xpcf  = org::bcom::xpcf;
+
+namespace SolAR {
+using namespace datastructure;
+namespace MODULES {
+namespace OPENCV {
+
+SolARProjectOpencv::SolARProjectOpencv():ConfigurableBase(xpcf::toUUID<SolARProjectOpencv>())
+{
+    addInterface<api::geom::IProject>(this);
+
+    m_camMatrix.create(3, 3, CV_32FC1);
+    m_camDistorsion.create(5, 1, CV_32FC1);
+
+    LOG_DEBUG(" SolARProjectOpencv constructor");
+}
+
+SolARProjectOpencv::~SolARProjectOpencv(){
+
+}
+
+FrameworkReturnCode SolARProjectOpencv::project(const std::vector<SRef<Point3Df>> & inputPoints, const Transform3Df& pose, std::vector<SRef<Point2Df>> & imagePoints)
+{
+
+    return FrameworkReturnCode::_SUCCESS;
+}
+
+void SolARProjectOpencv::setCameraParameters(const CamCalibration & intrinsicParams, const CamDistortion & distorsionParams) {
+    this->m_camDistorsion.at<float>(0, 0)  = distorsionParams(0);
+    this->m_camDistorsion.at<float>(1, 0)  = distorsionParams(1);
+    this->m_camDistorsion.at<float>(2, 0)  = distorsionParams(2);
+    this->m_camDistorsion.at<float>(3, 0)  = distorsionParams(3);
+    this->m_camDistorsion.at<float>(4, 0)  = distorsionParams(4);
+
+    this->m_camMatrix.at<float>(0, 0) = intrinsicParams(0,0);
+    this->m_camMatrix.at<float>(0, 1) = intrinsicParams(0,1);
+    this->m_camMatrix.at<float>(0, 2) = intrinsicParams(0,2);
+    this->m_camMatrix.at<float>(1, 0) = intrinsicParams(1,0);
+    this->m_camMatrix.at<float>(1, 1) = intrinsicParams(1,1);
+    this->m_camMatrix.at<float>(1, 2) = intrinsicParams(1,2);
+    this->m_camMatrix.at<float>(2, 0) = intrinsicParams(2,0);
+    this->m_camMatrix.at<float>(2, 1) = intrinsicParams(2,1);
+    this->m_camMatrix.at<float>(2, 2) = intrinsicParams(2,2);
+}
+
+}
+}
+}

--- a/src/SolARUnprojectplanarPointsOpencv.cpp
+++ b/src/SolARUnprojectplanarPointsOpencv.cpp
@@ -1,0 +1,75 @@
+/**
+ * @copyright Copyright (c) 2017 B-com http://www.b-com.com/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "SolARUnprojectPlanarPointsOpencv.h"
+#include "SolAROpenCVHelper.h"
+#include "core/Log.h"
+#include "opencv2/calib3d/calib3d.hpp"
+
+XPCF_DEFINE_FACTORY_CREATE_INSTANCE(SolAR::MODULES::OPENCV::SolARUnprojectPlanarPointsOpencv);
+
+namespace xpcf  = org::bcom::xpcf;
+
+namespace SolAR {
+using namespace datastructure;
+namespace MODULES {
+namespace OPENCV {
+
+SolARUnprojectPlanarPointsOpencv::SolARUnprojectPlanarPointsOpencv():ConfigurableBase(xpcf::toUUID<SolARUnprojectPlanarPointsOpencv>())
+{
+    addInterface<api::geom::IUnproject>(this);
+    SRef<xpcf::IPropertyMap> params = getPropertyRootNode();
+
+    m_camMatrix.create(3, 3, CV_32FC1);
+    m_camDistorsion.create(5, 1, CV_32FC1);
+
+    LOG_DEBUG(" SolARUnprojectPlanarPositionOpencv constructor");
+}
+
+SolARUnprojectPlanarPointsOpencv::~SolARUnprojectPlanarPointsOpencv(){
+
+}
+
+FrameworkReturnCode SolARUnprojectPlanarPointsOpencv::unproject(const std::vector<SRef<Point2Df>> & imagePoints,
+                                                                  const Transform3Df& pose,
+                                                                  std::vector<SRef<Point3Df>> & worldPoints)
+{
+
+    return FrameworkReturnCode::_SUCCESS;
+}
+
+void SolARUnprojectPlanarPointsOpencv::setCameraParameters(const CamCalibration & intrinsicParams, const CamDistortion & distorsionParams) {
+
+    this->m_camDistorsion.at<float>(0, 0)  = distorsionParams(0);
+    this->m_camDistorsion.at<float>(1, 0)  = distorsionParams(1);
+    this->m_camDistorsion.at<float>(2, 0)  = distorsionParams(2);
+    this->m_camDistorsion.at<float>(3, 0)  = distorsionParams(3);
+    this->m_camDistorsion.at<float>(4, 0)  = distorsionParams(4);
+
+    this->m_camMatrix.at<float>(0, 0) = intrinsicParams(0,0);
+    this->m_camMatrix.at<float>(0, 1) = intrinsicParams(0,1);
+    this->m_camMatrix.at<float>(0, 2) = intrinsicParams(0,2);
+    this->m_camMatrix.at<float>(1, 0) = intrinsicParams(1,0);
+    this->m_camMatrix.at<float>(1, 1) = intrinsicParams(1,1);
+    this->m_camMatrix.at<float>(1, 2) = intrinsicParams(1,2);
+    this->m_camMatrix.at<float>(2, 0) = intrinsicParams(2,0);
+    this->m_camMatrix.at<float>(2, 1) = intrinsicParams(2,1);
+    this->m_camMatrix.at<float>(2, 2) = intrinsicParams(2,2);
+}
+
+}
+}
+}

--- a/src/SolARUnprojectplanarPointsOpencv.cpp
+++ b/src/SolARUnprojectplanarPointsOpencv.cpp
@@ -43,12 +43,33 @@ SolARUnprojectPlanarPointsOpencv::~SolARUnprojectPlanarPointsOpencv(){
 
 }
 
-FrameworkReturnCode SolARUnprojectPlanarPointsOpencv::unproject(const std::vector<SRef<Point2Df>> & imagePoints,
-                                                                  const Transform3Df& pose,
-                                                                  std::vector<SRef<Point3Df>> & worldPoints)
+FrameworkReturnCode unprojectOCV(const std::vector<cv::Point2f>& imagePoints, std::vector<SRef<Point3Df>>& worldPoints, const Transform3Df& pose)
 {
+    // TODO
 
     return FrameworkReturnCode::_SUCCESS;
+}
+
+FrameworkReturnCode SolARUnprojectPlanarPointsOpencv::unproject(const std::vector<SRef<Point2Df>> & imagePoints,
+                                                                std::vector<SRef<Point3Df>> & worldPoints,
+                                                                const Transform3Df& pose)
+{
+    std::vector<cv::Point2f> cvPoints;
+    for (auto point : imagePoints)
+        cvPoints.push_back(cv::Point2f(point->getX(), point->getY()));
+
+    return unprojectOCV(cvPoints, worldPoints, pose);
+}
+
+FrameworkReturnCode SolARUnprojectPlanarPointsOpencv::unproject(const std::vector<SRef<Keypoint>> & imageKeypoints,
+                                                                std::vector<SRef<Point3Df>> & worldPoints,
+                                                                const Transform3Df& pose)
+{
+    std::vector<cv::Point2f> cvPoints;
+    for (auto point : imageKeypoints)
+        cvPoints.push_back(cv::Point2f(point->getX(), point->getY()));
+
+    return unprojectOCV(cvPoints, worldPoints, pose);
 }
 
 void SolARUnprojectPlanarPointsOpencv::setCameraParameters(const CamCalibration & intrinsicParams, const CamDistortion & distorsionParams) {

--- a/src/SolARUnprojectplanarPointsOpencv.cpp
+++ b/src/SolARUnprojectplanarPointsOpencv.cpp
@@ -72,6 +72,8 @@ FrameworkReturnCode SolARUnprojectPlanarPointsOpencv::unproject(const std::vecto
                                                                 std::vector<SRef<Point3Df>> & worldPoints,
                                                                 const Transform3Df& pose)
 {
+    if (imagePoints.empty())
+        return FrameworkReturnCode::_ERROR_;
     std::vector<cv::Point2f> cvPoints;
     for (auto point : imagePoints)
         cvPoints.push_back(cv::Point2f(point->getX(), point->getY()));
@@ -83,6 +85,8 @@ FrameworkReturnCode SolARUnprojectPlanarPointsOpencv::unproject(const std::vecto
                                                                 std::vector<SRef<Point3Df>> & worldPoints,
                                                                 const Transform3Df& pose)
 {
+    if (imageKeypoints.empty())
+        return FrameworkReturnCode::_ERROR_;
     std::vector<cv::Point2f> cvPoints;
     for (auto point : imageKeypoints)
         cvPoints.push_back(cv::Point2f(point->getX(), point->getY()));

--- a/tests/SolARCameraCalibration/static/SolARCameraCalibration.pro
+++ b/tests/SolARCameraCalibration/static/SolARCameraCalibration.pro
@@ -1,5 +1,5 @@
 TARGET =SolARCameraCalibrationOpenCVTest
-VERSION=1.0.0
+VERSION=0.5.2
 
 CONFIG += c++11
 CONFIG -= qt

--- a/tests/SolARCameraCalibration/static/packagedependencies.txt
+++ b/tests/SolARCameraCalibration/static/packagedependencies.txt
@@ -1,5 +1,5 @@
-SolARFramework|0.5.1|SolARFramework|bcomBuild|url_repo_artifactory
-SolARModuleOpenCV|0.5.1|SolARModuleOpenCV|bcomBuild|url_repo_artifactory
+SolARFramework|0.5.2|SolARFramework|bcomBuild|url_repo_artifactory
+SolARModuleOpenCV|0.5.2|SolARModuleOpenCV|bcomBuild|url_repo_artifactory
 xpcf|2.1.0|xpcf|thirdParties|http://repository.b-com.com/
 boost|1.68.0|boost|thirdParties|http://repository.b-com.com/
 opencv|3.4.3|opencv|thirdParties|http://repository.b-com.com/

--- a/tests/SolARDescriptorMatcher/dynamic/SolARDescriptorMatcherOpenCVDynTest.pro
+++ b/tests/SolARDescriptorMatcher/dynamic/SolARDescriptorMatcherOpenCVDynTest.pro
@@ -1,5 +1,5 @@
 TARGET = SolARDescriptorMatcherOpenCVDynTest
-VERSION=0.5.1
+VERSION=0.5.2
 
 CONFIG += c++11
 CONFIG -= qt

--- a/tests/SolARDescriptorMatcher/dynamic/conf_DescriptorMatcher.xml
+++ b/tests/SolARDescriptorMatcher/dynamic/conf_DescriptorMatcher.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <xpcf-registry>
     
-	<module uuid="15e1990b-86b2-445c-8194-0cbe80ede970" name="SolARModuleOpenCV" description="SolARModuleOpenCV" path="$BCOMDEVROOT/bcomBuild/SolARModuleOpenCV/0.5.1/lib/x86_64/shared">
+	<module uuid="15e1990b-86b2-445c-8194-0cbe80ede970" name="SolARModuleOpenCV" description="SolARModuleOpenCV" path="$BCOMDEVROOT/bcomBuild/SolARModuleOpenCV/0.5.2/lib/x86_64/shared">
         <component uuid="e42d6526-9eb1-4f8a-bb68-53e06f09609c" name="SolARImageLoaderOpencv" description="SolARImageLoaderOpencv">
                 <interface uuid="125f2007-1bf9-421d-9367-fbdc1210d006" name="IComponentIntrospect" description="IComponentIntrospect"/>
                 <interface uuid="6FCDAA8D-6EA9-4C3F-97B0-46CD11B67A9B" name="IImageLoader" description="IImageLoader"/>

--- a/tests/SolARDescriptorMatcher/dynamic/packagedependencies.txt
+++ b/tests/SolARDescriptorMatcher/dynamic/packagedependencies.txt
@@ -1,5 +1,5 @@
-SolARFramework|0.5.1|SolARFramework|bcomBuild|url_repo_artifactory
-SolARModuleOpenCV|0.5.1|SolARModuleOpenCV|bcomBuild|url_repo_artifactory
+SolARFramework|0.5.2|SolARFramework|bcomBuild|url_repo_artifactory
+SolARModuleOpenCV|0.5.2|SolARModuleOpenCV|bcomBuild|url_repo_artifactory
 xpcf|2.1.0|xpcf|thirdParties|http://repository.b-com.com/
 boost|1.68.0|boost|thirdParties|http://repository.b-com.com/
 opencv|3.4.3|opencv|thirdParties|http://repository.b-com.com/

--- a/tests/SolARFiducialMarker/dynamic/CMakeLists.txt
+++ b/tests/SolARFiducialMarker/dynamic/CMakeLists.txt
@@ -1,0 +1,47 @@
+cmake_minimum_required(VERSION 3.7.2)
+
+##################################################
+project("SolARMarker2DFiducialOpenCVStaticTest")
+set (SOURCES main.cpp)
+##################################################
+
+# various macros
+include("$ENV{BCOMDEVROOT}/bcomBuild/SolARFramework/solarmacros.cmake")
+# config setup
+setup()
+# process packagedependencies.txt
+processPackagedependencies()
+
+# define the list of files to copy to build directory
+if (UNIX)
+	set (LIBPREFIX "lib")
+	set (LIBEXTENSION "so")
+	set (OPENCV_VERSION "")
+endif(UNIX)
+if (WIN32)
+	set (LIBPREFIX "")
+	set (LIBEXTENSION "dll")
+	set (OPENCV_VERSION "343")	
+endif(WIN32)
+set (BUILDCONFIG $<$<CONFIG:Debug>:debug>$<$<NOT:$<CONFIG:Debug>>:release>)
+
+set(FILES_TO_COPY
+
+	$ENV{BCOMDEVROOT}/thirdParties/opencv/3.4.3/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}opencv_world${OPENCV_VERSION}.${LIBEXTENSION}
+
+	$ENV{BCOMDEVROOT}/thirdParties/boost/1.68.0/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}boost_filesystem.${LIBEXTENSION}
+	$ENV{BCOMDEVROOT}/thirdParties/boost/1.68.0/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}boost_system.${LIBEXTENSION}
+	$ENV{BCOMDEVROOT}/thirdParties/boost/1.68.0/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}boost_timer.${LIBEXTENSION}
+	$ENV{BCOMDEVROOT}/thirdParties/boost/1.68.0/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}boost_log.${LIBEXTENSION}
+	$ENV{BCOMDEVROOT}/thirdParties/boost/1.68.0/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}boost_chrono.${LIBEXTENSION}
+	$ENV{BCOMDEVROOT}/thirdParties/boost/1.68.0/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}boost_thread.${LIBEXTENSION}
+	$ENV{BCOMDEVROOT}/thirdParties/boost/1.68.0/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}boost_date_time.${LIBEXTENSION}
+
+	$ENV{BCOMDEVROOT}/bcomBuild/SolARModuleOpenCV/0.4.0/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}SolARModuleOpenCV.${LIBEXTENSION}
+	$ENV{BCOMDEVROOT}/bcomBuild/SolARFramework/0.4.0/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}SolARFramework.${LIBEXTENSION}
+	$ENV{BCOMDEVROOT}/bcomBuild/SolARModuleTools/0.4.0/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}SolARModuleTools.${LIBEXTENSION}
+	$ENV{BCOMDEVROOT}/thirdParties/xpcf/2.0.1/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}xpcf.${LIBEXTENSION}
+	)
+# define targets (library, install and uninstall)
+defineTargets("executable" "${FILES_TO_COPY}")
+

--- a/tests/SolARFiducialMarker/dynamic/SolARMarker2DFiducialOpenCVTest.pro
+++ b/tests/SolARFiducialMarker/dynamic/SolARMarker2DFiducialOpenCVTest.pro
@@ -1,5 +1,5 @@
 TARGET = SolARMarker2DFiducialOpenCVTest
-VERSION=0.5.1
+VERSION=0.5.2
 
 CONFIG += c++11
 CONFIG -= qt

--- a/tests/SolARFiducialMarker/dynamic/conf_FiducialMarker.xml
+++ b/tests/SolARFiducialMarker/dynamic/conf_FiducialMarker.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <xpcf-registry>
-	<module uuid="15e1990b-86b2-445c-8194-0cbe80ede970" name="SolARModuleOpenCV" description="SolARModuleOpenCV module" path="$BCOMDEVROOT/bcomBuild/SolARModuleOpenCV/0.5.1/lib/x86_64/shared">
+	<module uuid="15e1990b-86b2-445c-8194-0cbe80ede970" name="SolARModuleOpenCV" description="SolARModuleOpenCV module" path="$BCOMDEVROOT/bcomBuild/SolARModuleOpenCV/0.5.2/lib/x86_64/shared">
         <component uuid="5d2b8da9-528e-4e5e-96c1-f883edcf3b1c" name="SolARMarker2DSquaredBinaryOpencv" description="SolARMarker2DSquaredBinaryOpencv">
                 <interface uuid="125f2007-1bf9-421d-9367-fbdc1210d006" name="IComponentIntrospect" description="IComponentIntrospect"/>
                 <interface uuid="3c9cee8a-e9ca-4c16-851a-669a94c2a68d" name="IMarker" description="IMarker"/>

--- a/tests/SolARFiducialMarker/dynamic/packagedependencies.txt
+++ b/tests/SolARFiducialMarker/dynamic/packagedependencies.txt
@@ -1,5 +1,5 @@
-SolARFramework|0.5.1|SolARFramework|bcomBuild|url_repo_artifactory
-SolARModuleOpenCV|0.5.1|SolARModuleOpenCV|bcomBuild|url_repo_artifactory
+SolARFramework|0.5.2|SolARFramework|bcomBuild|url_repo_artifactory
+SolARModuleOpenCV|0.5.2|SolARModuleOpenCV|bcomBuild|url_repo_artifactory
 xpcf|2.1.0|xpcf|thirdParties|http://repository.b-com.com/
 boost|1.68.0|boost|thirdParties|http://repository.b-com.com/
 opencv|3.4.3|opencv|thirdParties|http://repository.b-com.com/

--- a/tests/SolARFundamentalMatrixDecomposer/SolARFundamentalMatrixDecomposerOpenCVTest.pro
+++ b/tests/SolARFundamentalMatrixDecomposer/SolARFundamentalMatrixDecomposerOpenCVTest.pro
@@ -1,5 +1,5 @@
 TARGET = SolARFundamentalMatrixDecomposerOpencvTest
-VERSION=0.5.1
+VERSION=0.5.2
 
 CONFIG += c++11
 CONFIG -= qt

--- a/tests/SolARFundamentalMatrixDecomposer/conf_FundamentalMatrixDecomposer.xml
+++ b/tests/SolARFundamentalMatrixDecomposer/conf_FundamentalMatrixDecomposer.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <xpcf-registry>
-	<module uuid="15e1990b-86b2-445c-8194-0cbe80ede970" name="SolARModuleOpenCV" description="SolARModuleOpenCV" path="$BCOMDEVROOT/bcomBuild/SolARModuleOpenCV/0.5.1/lib/x86_64/shared">
+	<module uuid="15e1990b-86b2-445c-8194-0cbe80ede970" name="SolARModuleOpenCV" description="SolARModuleOpenCV" path="$BCOMDEVROOT/bcomBuild/SolARModuleOpenCV/0.5.2/lib/x86_64/shared">
          <component uuid="5B7396F4-A804-4F3C-A0EB-FB1D56042BB4" name="SolARCameraOpencv" description="SolARCameraOpencv">
                 <interface uuid="125f2007-1bf9-421d-9367-fbdc1210d006" name="IComponentIntrospect" description="IComponentIntrospect"/>
                 <interface uuid="5DDC7DF0-8377-437F-9C81-3643F7676A5B" name="ICamera" description="ICamera"/>

--- a/tests/SolARFundamentalMatrixDecomposer/packagedependencies.txt
+++ b/tests/SolARFundamentalMatrixDecomposer/packagedependencies.txt
@@ -1,5 +1,5 @@
-SolARFramework|0.5.1|SolARFramework|bcomBuild|url_repo_artifactory
-SolARModuleOpenCV|0.5.1|SolARModuleOpenCV|bcomBuild|url_repo_artifactory
+SolARFramework|0.5.2|SolARFramework|bcomBuild|url_repo_artifactory
+SolARModuleOpenCV|0.5.2|SolARModuleOpenCV|bcomBuild|url_repo_artifactory
 xpcf|2.1.0|xpcf|thirdParties|http://repository.b-com.com/
 boost|1.68.0|boost|thirdParties|http://repository.b-com.com/
 opencv|3.4.3|opencv|thirdParties|http://repository.b-com.com/

--- a/tests/SolARFundamentalMatrixEstimation/CMakeLists.txt
+++ b/tests/SolARFundamentalMatrixEstimation/CMakeLists.txt
@@ -1,0 +1,47 @@
+cmake_minimum_required(VERSION 3.7.2)
+
+##################################################
+project("SolARFundamentalMatrixEstimation")
+set (SOURCES main.cpp)
+##################################################
+
+# various macros
+include("$ENV{BCOMDEVROOT}/bcomBuild/SolARFramework/solarmacros.cmake")
+# config setup
+setup()
+# process packagedependencies.txt
+processPackagedependencies()
+
+# define the list of files to copy to build directory
+if (UNIX)
+	set (LIBPREFIX "lib")
+	set (LIBEXTENSION "so")
+	set (OPENCV_VERSION "")
+endif(UNIX)
+if (WIN32)
+	set (LIBPREFIX "")
+	set (LIBEXTENSION "dll")
+	set (OPENCV_VERSION "343")	
+endif(WIN32)
+set (BUILDCONFIG $<$<CONFIG:Debug>:debug>$<$<NOT:$<CONFIG:Debug>>:release>)
+
+set(FILES_TO_COPY
+
+	$ENV{BCOMDEVROOT}/thirdParties/opencv/3.4.3/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}opencv_world${OPENCV_VERSION}.${LIBEXTENSION}
+
+	$ENV{BCOMDEVROOT}/thirdParties/boost/1.64.0/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}boost_filesystem.${LIBEXTENSION}
+	$ENV{BCOMDEVROOT}/thirdParties/boost/1.64.0/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}boost_system.${LIBEXTENSION}
+	$ENV{BCOMDEVROOT}/thirdParties/boost/1.64.0/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}boost_timer.${LIBEXTENSION}
+	$ENV{BCOMDEVROOT}/thirdParties/boost/1.64.0/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}boost_log.${LIBEXTENSION}
+	$ENV{BCOMDEVROOT}/thirdParties/boost/1.64.0/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}boost_chrono.${LIBEXTENSION}
+	$ENV{BCOMDEVROOT}/thirdParties/boost/1.64.0/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}boost_thread.${LIBEXTENSION}
+	$ENV{BCOMDEVROOT}/thirdParties/boost/1.64.0/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}boost_date_time.${LIBEXTENSION}
+
+	$ENV{BCOMDEVROOT}/bcomBuild/SolARModuleOpenCV/0.4.0/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}SolARModuleOpenCV.${LIBEXTENSION}
+	$ENV{BCOMDEVROOT}/bcomBuild/SolARFramework/0.4.0/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}SolARFramework.${LIBEXTENSION}
+	$ENV{BCOMDEVROOT}/bcomBuild/SolARModuleTools/0.4.0/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}SolARModuleTools.${LIBEXTENSION}
+	$ENV{BCOMDEVROOT}/thirdParties/xpcf/2.0.0/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}xpcf.${LIBEXTENSION}
+	)
+# define targets (library, install and uninstall)
+defineTargets("executable" "${FILES_TO_COPY}")
+

--- a/tests/SolARFundamentalMatrixEstimation/SolARFundamentalMatrixEstimationOpenCVTest.pro
+++ b/tests/SolARFundamentalMatrixEstimation/SolARFundamentalMatrixEstimationOpenCVTest.pro
@@ -1,5 +1,5 @@
 TARGET = SolARFundamentalMatrixEstimationOpencvTest
-VERSION=0.5.1
+VERSION=0.5.2
 
 CONFIG += c++11
 CONFIG -= qt

--- a/tests/SolARFundamentalMatrixEstimation/conf_FundamentalMatrixEstimation.xml
+++ b/tests/SolARFundamentalMatrixEstimation/conf_FundamentalMatrixEstimation.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <xpcf-registry>
-	<module uuid="15e1990b-86b2-445c-8194-0cbe80ede970" name="SolARModuleOpenCV" description="SolARModuleOpenCV" path="$BCOMDEVROOT/bcomBuild/SolARModuleOpenCV/0.5.1/lib/x86_64/shared">
+	<module uuid="15e1990b-86b2-445c-8194-0cbe80ede970" name="SolARModuleOpenCV" description="SolARModuleOpenCV" path="$BCOMDEVROOT/bcomBuild/SolARModuleOpenCV/0.5.2/lib/x86_64/shared">
          <component uuid="5B7396F4-A804-4F3C-A0EB-FB1D56042BB4" name="SolARCameraOpencv" description="SolARCameraOpencv">
                 <interface uuid="125f2007-1bf9-421d-9367-fbdc1210d006" name="IComponentIntrospect" description="IComponentIntrospect"/>
                 <interface uuid="5DDC7DF0-8377-437F-9C81-3643F7676A5B" name="ICamera" description="ICamera"/>

--- a/tests/SolARFundamentalMatrixEstimation/packagedependencies.txt
+++ b/tests/SolARFundamentalMatrixEstimation/packagedependencies.txt
@@ -1,5 +1,5 @@
-SolARFramework|0.5.1|SolARFramework|bcomBuild|url_repo_artifactory
-SolARModuleOpenCV|0.5.1|SolARModuleOpenCV|bcomBuild|url_repo_artifactory
+SolARFramework|0.5.2|SolARFramework|bcomBuild|url_repo_artifactory
+SolARModuleOpenCV|0.5.2|SolARModuleOpenCV|bcomBuild|url_repo_artifactory
 xpcf|2.1.0|xpcf|thirdParties|http://repository.b-com.com/
 boost|1.68.0|boost|thirdParties|http://repository.b-com.com/
 opencv|3.4.3|opencv|thirdParties|http://repository.b-com.com/

--- a/tests/SolARImageConvertor/dynamic/SolARImageConvertorOpencvTest.pro
+++ b/tests/SolARImageConvertor/dynamic/SolARImageConvertorOpencvTest.pro
@@ -1,5 +1,5 @@
 TARGET = SolARImageConvertorOpenCVTest
-VERSION=0.5.1
+VERSION=0.5.2
 
 CONFIG += c++11
 CONFIG -= qt

--- a/tests/SolARImageConvertor/dynamic/conf_ImageConvertor.xml
+++ b/tests/SolARImageConvertor/dynamic/conf_ImageConvertor.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <xpcf-registry>
-	<module uuid="15e1990b-86b2-445c-8194-0cbe80ede970" name="SolARModuleOpenCV" description="SolARModuleOpenCV" path="$BCOMDEVROOT/bcomBuild/SolARModuleOpenCV/0.5.1/lib/x86_64/shared">
+	<module uuid="15e1990b-86b2-445c-8194-0cbe80ede970" name="SolARModuleOpenCV" description="SolARModuleOpenCV" path="$BCOMDEVROOT/bcomBuild/SolARModuleOpenCV/0.5.2/lib/x86_64/shared">
         <component uuid="e42d6526-9eb1-4f8a-bb68-53e06f09609c" name="SolARImageLoaderOpencv" description="SolARImageLoaderOpencv">
                 <interface uuid="125f2007-1bf9-421d-9367-fbdc1210d006" name="IComponentIntrospect" description="IComponentIntrospect"/>
                 <interface uuid="6FCDAA8D-6EA9-4C3F-97B0-46CD11B67A9B" name="IImageLoader" description="IImageLoader"/>

--- a/tests/SolARImageConvertor/dynamic/packagedependencies.txt
+++ b/tests/SolARImageConvertor/dynamic/packagedependencies.txt
@@ -1,5 +1,5 @@
-SolARFramework|0.5.1|SolARFramework|bcomBuild|url_repo_artifactory
-SolARModuleOpenCV|0.5.1|SolARModuleOpenCV|bcomBuild|url_repo_artifactory
+SolARFramework|0.5.2|SolARFramework|bcomBuild|url_repo_artifactory
+SolARModuleOpenCV|0.5.2|SolARModuleOpenCV|bcomBuild|url_repo_artifactory
 xpcf|2.1.0|xpcf|thirdParties|http://repository.b-com.com/
 boost|1.68.0|boost|thirdParties|http://repository.b-com.com/
 opencv|3.4.3|opencv|thirdParties|http://repository.b-com.com/

--- a/tests/SolARImageLoader/dynamic/SolARImageOpenCVDynTest.pro
+++ b/tests/SolARImageLoader/dynamic/SolARImageOpenCVDynTest.pro
@@ -1,5 +1,5 @@
 TARGET = SolARImageOpenCVDynTest
-VERSION=0.5.1
+VERSION=0.5.2
 
 CONFIG += c++11
 CONFIG -= qt

--- a/tests/SolARImageLoader/dynamic/conf_ImageLoader.xml
+++ b/tests/SolARImageLoader/dynamic/conf_ImageLoader.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <xpcf-registry>
-	<module uuid="15e1990b-86b2-445c-8194-0cbe80ede970" name="SolARModuleOpenCV" description="SolARModuleOpenCV" path="$BCOMDEVROOT/bcomBuild/SolARModuleOpenCV/0.5.1/lib/x86_64/shared">
+	<module uuid="15e1990b-86b2-445c-8194-0cbe80ede970" name="SolARModuleOpenCV" description="SolARModuleOpenCV" path="$BCOMDEVROOT/bcomBuild/SolARModuleOpenCV/0.5.2/lib/x86_64/shared">
         <component uuid="e42d6526-9eb1-4f8a-bb68-53e06f09609c" name="SolARImageLoaderOpencv" description="SolARImageLoaderOpencv">
                 <interface uuid="125f2007-1bf9-421d-9367-fbdc1210d006" name="IComponentIntrospect" description="IComponentIntrospect"/>
                 <interface uuid="6FCDAA8D-6EA9-4C3F-97B0-46CD11B67A9B" name="IImageLoader" description="IImageLoader"/>

--- a/tests/SolARImageLoader/dynamic/packagedependencies.txt
+++ b/tests/SolARImageLoader/dynamic/packagedependencies.txt
@@ -1,5 +1,5 @@
-SolARFramework|0.5.1|SolARFramework|bcomBuild|url_repo_artifactory
-SolARModuleOpenCV|0.5.1|SolARModuleOpenCV|bcomBuild|url_repo_artifactory
+SolARFramework|0.5.2|SolARFramework|bcomBuild|url_repo_artifactory
+SolARModuleOpenCV|0.5.2|SolARModuleOpenCV|bcomBuild|url_repo_artifactory
 xpcf|2.1.0|xpcf|thirdParties|http://repository.b-com.com/
 boost|1.68.0|boost|thirdParties|http://repository.b-com.com/
 spdlog|0.14.0|spdlog|thirdParties|http://repository.b-com.com/

--- a/tests/SolARMatchesFilter/CMakeLists.txt
+++ b/tests/SolARMatchesFilter/CMakeLists.txt
@@ -1,0 +1,47 @@
+cmake_minimum_required(VERSION 3.7.2)
+
+##################################################
+project("SolARMatchesFilterTest")
+set (SOURCES main.cpp)
+##################################################
+
+# various macros
+include("$ENV{BCOMDEVROOT}/bcomBuild/SolARFramework/solarmacros.cmake")
+# config setup
+setup()
+# process packagedependencies.txt
+processPackagedependencies()
+
+# define the list of files to copy to build directory
+if (UNIX)
+	set (LIBPREFIX "lib")
+	set (LIBEXTENSION "so")
+	set (OPENCV_VERSION "")
+endif(UNIX)
+if (WIN32)
+	set (LIBPREFIX "")
+	set (LIBEXTENSION "dll")
+	set (OPENCV_VERSION "343")	
+endif(WIN32)
+set (BUILDCONFIG $<$<CONFIG:Debug>:debug>$<$<NOT:$<CONFIG:Debug>>:release>)
+
+set(FILES_TO_COPY
+
+	$ENV{BCOMDEVROOT}/thirdParties/opencv/3.4.3/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}opencv_world${OPENCV_VERSION}.${LIBEXTENSION}
+
+	$ENV{BCOMDEVROOT}/thirdParties/boost/1.64.0/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}boost_filesystem.${LIBEXTENSION}
+	$ENV{BCOMDEVROOT}/thirdParties/boost/1.64.0/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}boost_system.${LIBEXTENSION}
+	$ENV{BCOMDEVROOT}/thirdParties/boost/1.64.0/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}boost_timer.${LIBEXTENSION}
+	$ENV{BCOMDEVROOT}/thirdParties/boost/1.64.0/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}boost_log.${LIBEXTENSION}
+	$ENV{BCOMDEVROOT}/thirdParties/boost/1.64.0/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}boost_chrono.${LIBEXTENSION}
+	$ENV{BCOMDEVROOT}/thirdParties/boost/1.64.0/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}boost_thread.${LIBEXTENSION}
+	$ENV{BCOMDEVROOT}/thirdParties/boost/1.64.0/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}boost_date_time.${LIBEXTENSION}
+
+	$ENV{BCOMDEVROOT}/bcomBuild/SolARModuleOpenCV/0.4.0/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}SolARModuleOpenCV.${LIBEXTENSION}
+	$ENV{BCOMDEVROOT}/bcomBuild/SolARFramework/0.4.0/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}SolARFramework.${LIBEXTENSION}
+	$ENV{BCOMDEVROOT}/bcomBuild/SolARModuleTools/0.4.0/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}SolARModuleTools.${LIBEXTENSION}
+	$ENV{BCOMDEVROOT}/thirdParties/xpcf/2.0.0/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}xpcf.${LIBEXTENSION}
+	)
+# define targets (library, install and uninstall)
+defineTargets("executable" "${FILES_TO_COPY}")
+

--- a/tests/SolARMatchesFilter/SolARMatchesFilterTest.pro
+++ b/tests/SolARMatchesFilter/SolARMatchesFilterTest.pro
@@ -1,5 +1,5 @@
 TARGET = SolARMatchesFilterTest
-VERSION=0.5.1
+VERSION=0.5.2
 
 CONFIG += c++11
 CONFIG -= qt

--- a/tests/SolARMatchesFilter/conf_MatchesFilter.xml
+++ b/tests/SolARMatchesFilter/conf_MatchesFilter.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <xpcf-registry>
-	<module uuid="15e1990b-86b2-445c-8194-0cbe80ede970" name="SolARModuleOpenCV" description="SolARModuleOpenCV" path="$BCOMDEVROOT/bcomBuild/SolARModuleOpenCV/0.5.1/lib/x86_64/shared">
+	<module uuid="15e1990b-86b2-445c-8194-0cbe80ede970" name="SolARModuleOpenCV" description="SolARModuleOpenCV" path="$BCOMDEVROOT/bcomBuild/SolARModuleOpenCV/0.5.2/lib/x86_64/shared">
         <component uuid="e42d6526-9eb1-4f8a-bb68-53e06f09609c" name="SolARImageLoaderOpencv" description="SolARImageLoaderOpencv">
                 <interface uuid="125f2007-1bf9-421d-9367-fbdc1210d006" name="IComponentIntrospect" description="IComponentIntrospect"/>
                 <interface uuid="6FCDAA8D-6EA9-4C3F-97B0-46CD11B67A9B" name="IImageLoader" description="IImageLoader"/>

--- a/tests/SolARMatchesFilter/packagedependencies.txt
+++ b/tests/SolARMatchesFilter/packagedependencies.txt
@@ -1,5 +1,5 @@
-SolARFramework|0.5.1|SolARFramework|bcomBuild|url_repo_artifactory
-SolARModuleOpenCV|0.5.1|SolARModuleOpenCV|bcomBuild|url_repo_artifactory
+SolARFramework|0.5.2|SolARFramework|bcomBuild|url_repo_artifactory
+SolARModuleOpenCV|0.5.2|SolARModuleOpenCV|bcomBuild|url_repo_artifactory
 xpcf|2.1.0|xpcf|thirdParties|http://repository.b-com.com/
 opencv|3.4.3|opencv|thirdParties|http://repository.b-com.com/
 boost|1.68.0|boost|thirdParties|http://repository.b-com.com/

--- a/tests/SolAROpticalFlow/CMakeLists.txt
+++ b/tests/SolAROpticalFlow/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.7.2)
+
+##################################################
+project("SolAROpticalFlowOpenCVTest")
+set (SOURCES main.cpp)
+##################################################
+
+# various macros
+include("$ENV{BCOMDEVROOT}/bcomBuild/SolARFramework/solarmacros.cmake")
+# config setup
+setup()
+# process packagedependencies.txt
+processPackagedependencies()
+
+# define the list of files to copy to build directory
+set(FILES_TO_COPY
+	$ENV{BCOMDEVROOT}/thirdParties/opencv/${OPENCV_VERSION}/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}opencv_world${OPENCVVERSIONSUFFIX}.${LIBEXTENSION}
+
+	$ENV{BCOMDEVROOT}/thirdParties/boost/${BOOST_VERSION}/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}boost_filesystem.${LIBEXTENSION}
+	$ENV{BCOMDEVROOT}/thirdParties/boost/${BOOST_VERSION}/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}boost_system.${LIBEXTENSION}
+	$ENV{BCOMDEVROOT}/thirdParties/boost/${BOOST_VERSION}/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}boost_timer.${LIBEXTENSION}
+	$ENV{BCOMDEVROOT}/thirdParties/boost/${BOOST_VERSION}/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}boost_log.${LIBEXTENSION}
+	$ENV{BCOMDEVROOT}/thirdParties/boost/${BOOST_VERSION}/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}boost_chrono.${LIBEXTENSION}
+	$ENV{BCOMDEVROOT}/thirdParties/boost/${BOOST_VERSION}/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}boost_thread.${LIBEXTENSION}
+	$ENV{BCOMDEVROOT}/thirdParties/boost/${BOOST_VERSION}/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}boost_date_time.${LIBEXTENSION}
+
+	$ENV{BCOMDEVROOT}/bcomBuild/SolARModuleOpenCV/${SOLARMODULEOPENCV_VERSION}/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}SolARModuleOpenCV.${LIBEXTENSION}
+	$ENV{BCOMDEVROOT}/bcomBuild/SolARFramework/${SOLARFRAMEWORK_VERSION}/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}SolARFramework.${LIBEXTENSION}
+	$ENV{BCOMDEVROOT}/thirdParties/xpcf/${XPCF_VERSION}/lib/x86_64/shared/${BUILDCONFIG}/${LIBPREFIX}xpcf.${LIBEXTENSION}	
+	)
+# define targets (library, install and uninstall)
+defineTargets("executable" "${FILES_TO_COPY}")
+

--- a/tests/SolAROpticalFlow/SolAROpticalFlowTest.pro
+++ b/tests/SolAROpticalFlow/SolAROpticalFlowTest.pro
@@ -1,0 +1,47 @@
+TARGET = SolARopticalFlowOpenCVTest
+VERSION=0.5.1
+
+CONFIG += c++11
+CONFIG -= qt
+CONFIG += console
+
+DEFINES += MYVERSION=$${VERSION}
+
+CONFIG(debug,debug|release) {
+    DEFINES += _DEBUG=1
+    DEFINES += DEBUG=1
+}
+
+CONFIG(release,debug|release) {
+    DEFINES += NDEBUG=1
+}
+
+win32:CONFIG -= static
+win32:CONFIG += shared
+
+DEPENDENCIESCONFIG = sharedlib
+#NOTE : CONFIG as staticlib or sharedlib, DEPENDENCIESCONFIG as staticlib or sharedlib MUST BE DEFINED BEFORE templateappconfig.pri inclusion
+include ($$(BCOMDEVROOT)/builddefs/qmake/templateappconfig.pri)
+
+SOURCES += \
+    main.cpp
+
+unix {
+LIBS += -ldl
+}
+
+macx {
+    QMAKE_MAC_SDK= macosx
+    QMAKE_CXXFLAGS += -fasm-blocks -x objective-c++
+}
+
+win32 {
+    QMAKE_LFLAGS += /MACHINE:X64
+    DEFINES += WIN64 UNICODE _UNICODE
+    QMAKE_COMPILER_DEFINES += _WIN64
+
+    # Windows Kit (msvc2013 64)
+    LIBS += -L$$(WINDOWSSDKDIR)lib/winv6.3/um/x64 -lshell32 -lgdi32 -lComdlg32
+    INCLUDEPATH += $$(WINDOWSSDKDIR)lib/winv6.3/um/x64
+
+}

--- a/tests/SolAROpticalFlow/SolAROpticalFlowTest.pro
+++ b/tests/SolAROpticalFlow/SolAROpticalFlowTest.pro
@@ -1,5 +1,5 @@
 TARGET = SolARopticalFlowOpenCVTest
-VERSION=0.5.1
+VERSION=0.5.2
 
 CONFIG += c++11
 CONFIG -= qt

--- a/tests/SolAROpticalFlow/camera_calibration.yml
+++ b/tests/SolAROpticalFlow/camera_calibration.yml
@@ -1,0 +1,22 @@
+%YAML:1.0
+---
+calibration_time: "Wed Dec  6 14:02:31 2017"
+image_width: 640
+image_height: 480
+board_width: 9
+board_height: 6
+square_size: 2.6000000536441803e-02
+flags: 0
+camera_matrix: !!opencv-matrix
+   rows: 3
+   cols: 3
+   dt: d
+   data: [ 6.2358844756875726e+02, 0., 3.1296501379528701e+02, 0.,
+       6.2510924611650637e+02, 2.6595453191051286e+02, 0., 0., 1. ]
+distortion_coefficients: !!opencv-matrix
+   rows: 5
+   cols: 1
+   dt: d
+   data: [ 5.0406145631272294e-03, -7.3194070034412229e-01,
+       8.8401137738982200e-03, -4.1912068994392751e-03,
+       2.7609935737342024e+00 ]

--- a/tests/SolAROpticalFlow/conf_OpticalFlow.xml
+++ b/tests/SolAROpticalFlow/conf_OpticalFlow.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<xpcf-registry>
+    
+	<module uuid="15e1990b-86b2-445c-8194-0cbe80ede970" name="SolARModuleOpenCV" description="SolARModuleOpenCV" path="$BCOMDEVROOT/bcomBuild/SolARModuleOpenCV/0.5.2/lib/x86_64/shared">
+        <component uuid="5B7396F4-A804-4F3C-A0EB-FB1D56042BB4" name="SolARCameraOpencv" description="SolARCameraOpencv">
+                <interface uuid="125f2007-1bf9-421d-9367-fbdc1210d006" name="IComponentIntrospect" description="IComponentIntrospect"/>
+                <interface uuid="5DDC7DF0-8377-437F-9C81-3643F7676A5B" name="ICamera" description="ICamera"/>
+        </component>
+		<component uuid="e42d6526-9eb1-4f8a-bb68-53e06f09609c" name="SolARImageLoaderOpencv" description="SolARImageLoaderOpencv">
+                <interface uuid="125f2007-1bf9-421d-9367-fbdc1210d006" name="IComponentIntrospect" description="IComponentIntrospect"/>
+                <interface uuid="6FCDAA8D-6EA9-4C3F-97B0-46CD11B67A9B" name="IImageLoader" description="IImageLoader"/>
+        </component>
+		<component uuid="e81c7e4e-7da6-476a-8eba-078b43071272" name="SolARKeypointDetectorOpencv" description="SolARKeypointDetectorOpencv">
+                <interface uuid="125f2007-1bf9-421d-9367-fbdc1210d006" name="IComponentIntrospect" description="IComponentIntrospect"/>
+                <interface uuid="0eadc8b7-1265-434c-a4c6-6da8a028e06e" name="IKeypointDetector" description="IKeypointDetector"/>
+        </component>
+		<component uuid="21238c00-26dd-11e8-b467-0ed5f89f718b" name="SolARDescriptorsExtractorAKAZE2Opencv" description="SolARDescriptorsExtractorAKAZE2Opencv">
+                <interface uuid="125f2007-1bf9-421d-9367-fbdc1210d006" name="IComponentIntrospect" description="IComponentIntrospect"/>
+                <interface uuid="c0e49ff1-0696-4fe6-85a8-9b2c1e155d2e" name="IDescriptorsExtractor" description="IDescriptorsExtractor"/>
+        </component>
+		<component uuid="b513e9ff-d2e7-4dcf-9a29-4ed95c512158" name="SolAROpticalFlowPyrLKOpencv" description="SolAROpticalFlowPyrLKOpencv">
+                <interface uuid="125f2007-1bf9-421d-9367-fbdc1210d006" name="IComponentIntrospect" description="IComponentIntrospect"/>
+                <interface uuid="3c74cd7f-950c-43ee-8886-9f4ddf763c27" name="IOpticalFlowEstimator" description="IDescriptorMatcher"/>
+        </component>
+		<component uuid="e95302be-3fe1-44e0-97bf-a98380464af9" name="SolARMatchesOverlayOpencv" description="SolARMatchesOverlayOpencv">
+                <interface uuid="125f2007-1bf9-421d-9367-fbdc1210d006" name="IComponentIntrospect" description="IComponentIntrospect"/>
+                <interface uuid="a801354a-3e00-467c-b390-48c76fa8c53a" name="IMatchesOverlay" description="IMatchesOverlay"/>
+        </component>
+		<component uuid="19ea4e13-7085-4e3f-92ca-93f200ffb01b" name="SolARImageViewerOpencv" description="SolARImageViewerOpencv">
+                <interface uuid="125f2007-1bf9-421d-9367-fbdc1210d006" name="IComponentIntrospect" description="IComponentIntrospect"/>
+                <interface uuid="b05f3dbb-f93d-465c-aee1-fb58e1480c42" name="IImageViewer" description="IImageViewer"/>
+        </component>   	
+    </module>
+	
+	<configuration>
+		<component uuid="5B7396F4-A804-4F3C-A0EB-FB1D56042BB4"> <!-- SolARCameraOpencv -->
+			<property name="calibrationFile" type="string" value="camera_calibration.yml"/>
+			<property name="deviceID" type="UnsignedInteger" value="1"/>
+		</component>
+		<component uuid="e81c7e4e-7da6-476a-8eba-078b43071272"> <!-- SolAROpticalFlowPyrLKOpencv -->
+			<property name="searchWinWidth" type="Integer" value="21"/>
+			<property name="searchWinHeight" type="Integer" value="21"/>
+			<property name="maxLevel" type="Integer" value="3"/>
+			<property name="minEigenThreshold" type="Double" value="-1.0"/>
+			<property name="maxSearchIterations" type="Integer" value="20"/>
+			<property name="searchWindowAccuracy" type="Float" value="0.03"/>
+        </component>
+		<component uuid="b513e9ff-d2e7-4dcf-9a29-4ed95c512158"> <!-- SolARKeypointDetectorOpencv -->
+			<property name="type" type="string" value="AKAZE2"/>
+			<property name="imageRatio" type="Float" value="0.5"/>
+			<property name="nbDescriptors" type="Integer" value="1000"/>
+        </component>
+		<component uuid="e95302be-3fe1-44e0-97bf-a98380464af9"> <!-- SolARMatchesOverlayOpencv -->
+            <property name="thickness" type="UnsignedInteger" value="1"/>
+			<property name="mode" type="string" value="COLOR"/>
+			<property name="color"  type="UnsignedInteger">
+				<value>0</value>
+				<value>255</value>
+				<value>0</value>
+			</property>
+			<property name="maxMatches" type="UnsignedInteger" value="-1"/>	
+        </component>
+		<component uuid="19ea4e13-7085-4e3f-92ca-93f200ffb01b"> <!-- SolARImageViewerOpencv -->
+			<property name="title" type="string" value="Matches (press esc key to exit)"/>
+			<property name="exitKey" type="Integer" value="27"/>
+			<property name="width" type="Integer" value="0"/>
+			<property name="height" type="Integer" value="0"/>
+		</component>	
+    </configuration>
+</xpcf-registry>

--- a/tests/SolAROpticalFlow/main.cpp
+++ b/tests/SolAROpticalFlow/main.cpp
@@ -1,0 +1,178 @@
+/**
+ * @copyright Copyright (c) 2017 B-com http://www.b-com.com/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "xpcf/xpcf.h"
+
+#include "SolARModuleOpencv_traits.h"
+#include "api/input/devices/ICamera.h"
+#include "api/features/IKeypointDetector.h"
+#include "api/display/IImageViewer.h"
+#include "api/display/IMatchesOverlay.h"
+#include "api/tracking/IOpticalFlowEstimator.h"
+#include "core/Log.h"
+
+#include <iostream>
+#include <boost/log/core.hpp>
+#include <string>
+#include <vector>
+
+using namespace SolAR;
+using namespace SolAR::MODULES::OPENCV;
+using namespace SolAR::datastructure;
+using namespace SolAR::api;
+
+namespace xpcf  = org::bcom::xpcf;
+
+int main(int argc,char** argv)
+{
+#if NDEBUG
+    boost::log::core::get()->set_logging_enabled(false);
+#endif
+
+    LOG_ADD_LOG_TO_CONSOLE();
+
+    /* instantiate component manager*/
+    /* this is needed in dynamic mode */
+    SRef<xpcf::IComponentManager> xpcfComponentManager = xpcf::getComponentManagerInstance();
+
+    try {
+
+        if(xpcfComponentManager->load("conf_OpticalFlow.xml")!=org::bcom::xpcf::_SUCCESS)
+        {
+            LOG_ERROR("Failed to load the configuration file conf_DescriptorMatcher.xml")
+            return -1;
+        }
+
+        // declare and create components
+        LOG_INFO("Start creating components");
+
+        SRef<input::devices::ICamera> camera = xpcfComponentManager->create<SolARCameraOpencv>()->bindTo<input::devices::ICamera>();
+        SRef<features::IKeypointDetector> keypointsDetector = xpcfComponentManager->create<SolARKeypointDetectorOpencv>()->bindTo<features::IKeypointDetector>();
+        SRef<tracking::IOpticalFlowEstimator> opticalFlowLK = xpcfComponentManager->create<SolAROpticalFlowPyrLKOpencv>()->bindTo<tracking::IOpticalFlowEstimator>();
+        SRef<display::IMatchesOverlay> overlay = xpcfComponentManager->create<SolARMatchesOverlayOpencv>()->bindTo<display::IMatchesOverlay>();
+        SRef<display::IImageViewer> viewer = xpcfComponentManager->create<SolARImageViewerOpencv>()->bindTo<display::IImageViewer>();
+
+
+        // declare data structures
+        SRef<Image>                 previousImage;
+        SRef<Image>                 currentImage;
+        std::vector<SRef<Keypoint>> keypointsToTrack;
+        std::vector<SRef<Point2Df>> pointsToTrack;
+        std::vector<SRef<Point2Df>> trackedPoints;
+        std::vector<SRef<Point2Df>> points1, points2;
+        std::vector<unsigned char>  opticalFlowStatus;
+        std::vector<float>          opticalFlowError;
+        SRef<Image>                 viewerImage;
+
+     // Start
+        // Start the camera
+        if (camera->start() != FrameworkReturnCode::_SUCCESS) // Camera
+        {
+            LOG_ERROR ("Camera cannot start");
+            return -1;
+        }
+
+        // Capture first image
+        if(camera->getNextImage(previousImage)==SolAR::FrameworkReturnCode::_ERROR_)
+        {
+            LOG_ERROR("Cannot capture next image");
+            return -1;
+        }
+
+
+        while (true)
+        {
+            // capture a new image
+            if(camera->getNextImage(currentImage)==SolAR::FrameworkReturnCode::_ERROR_)
+            {
+                LOG_ERROR("Cannot capture next image");
+                return -1;
+            }
+
+            // Detect the keypoints of the first image
+            keypointsDetector->detect(previousImage, keypointsToTrack);
+
+            bool trackingOK = true;
+            int trackingIteration = 0;
+            while (trackingOK)
+            {
+                if (trackingIteration == 0)
+                {
+                    // Estimate the optical flow between images. Here, with use the keypoint detected previously
+                    opticalFlowLK->estimate(previousImage, currentImage, keypointsToTrack, trackedPoints, opticalFlowStatus, opticalFlowError);
+                }
+                else
+                    // Estimate the optical flow between images. here, with use the point previously tracked
+                    opticalFlowLK->estimate(previousImage, currentImage, pointsToTrack, trackedPoints, opticalFlowStatus, opticalFlowError);
+
+
+                // Convert keypoints in point2Df and remove untracked points
+                points1.clear();
+                points2.clear();
+                for (int i = 0; i < trackedPoints.size(); i++)
+                {
+                    if (opticalFlowStatus[i] == 1)
+                    {
+                        if (trackingIteration == 0)
+                            points1.push_back(xpcf::utils::make_shared<Point2Df>(keypointsToTrack[i]->getX(), keypointsToTrack[i]->getY()));
+                        else
+                            points1.push_back(xpcf::utils::make_shared<Point2Df>(pointsToTrack[i]->getX(), pointsToTrack[i]->getY()));
+                        points2.push_back(xpcf::utils::make_shared<Point2Df>(trackedPoints[i]->getX(), trackedPoints[i]->getY()));
+                    }
+                }
+                // Draw the matches in a dedicated image
+                overlay->draw(currentImage, viewerImage, points1, points2);
+
+                // Display the image with matches in a viewer. If escape key is pressed, exit the loop.
+                if (viewer->display(viewerImage) == FrameworkReturnCode::_STOP)
+                {
+                    LOG_INFO("End of OpticalFlowOpenCVTest");
+                    return 0;
+                }
+
+                previousImage = currentImage;
+                pointsToTrack = points2;
+                trackingIteration ++;
+
+                if (points1.size() < 50)
+                {
+                    trackingOK = false;
+                    break;
+                }
+
+                // capture the ne image
+                if(camera->getNextImage(currentImage)==SolAR::FrameworkReturnCode::_ERROR_)
+                {
+                    LOG_ERROR("Cannot capture next image");
+                    return -1;
+                }
+
+            }
+        }
+    }
+    catch (xpcf::Exception e)
+    {
+        LOG_ERROR ("The following exception has been catched: {}", e.what());
+        return -1;
+    }
+
+    return 0;
+}
+
+
+
+
+

--- a/tests/SolAROpticalFlow/packagedependencies.txt
+++ b/tests/SolAROpticalFlow/packagedependencies.txt
@@ -1,0 +1,7 @@
+SolARFramework|0.5.2|SolARFramework|bcomBuild|url_repo_artifactory
+SolARModuleOpenCV|0.5.2|SolARModuleOpenCV|bcomBuild|url_repo_artifactory
+xpcf|2.1.0|xpcf|thirdParties|http://repository.b-com.com/
+boost|1.68.0|boost|thirdParties|http://repository.b-com.com/
+opencv|3.4.3|opencv|thirdParties|http://repository.b-com.com/
+spdlog|0.14.0|spdlog|thirdParties|http://repository.b-com.com/
+eigen|3.3.5|eigen|thirdParties|http://repository.b-com.com/amc-generic

--- a/unittests/SolARModuleOpenCVUnitTests.pro
+++ b/unittests/SolARModuleOpenCVUnitTests.pro
@@ -1,5 +1,5 @@
 TARGET = SolARModuleOpenCVUnitTests
-VERSION=1.0.0
+VERSION=0.5.2
 
 CONFIG += c++11
 CONFIG -= qt

--- a/unittests/filter/SolARImageFilterUnitTest.pro
+++ b/unittests/filter/SolARImageFilterUnitTest.pro
@@ -1,5 +1,5 @@
 TARGET = SolARImageOpenCVStaticTest
-VERSION=1.0.0
+VERSION=0.5.2
 
 CONFIG += c++11
 CONFIG -= qt

--- a/unittests/packagedependencies.txt
+++ b/unittests/packagedependencies.txt
@@ -1,6 +1,6 @@
 opencv|3.4.3|opencv|thirdParties|url_repo_artifactory
-SolARFramework|0.5.1|SolARFramework|bcomBuild|url_repo_artifactory
-SolARModuleOpenCV|0.5.1|SolARModuleOpenCV|bcomBuild|url_repo_artifactory
+SolARFramework|0.5.2|SolARFramework|bcomBuild|url_repo_artifactory
+SolARModuleOpenCV|0.5.2|SolARModuleOpenCV|bcomBuild|url_repo_artifactory
 xpcf|2.1.0|xpcf|thirdParties|http://repository.b-com.com/amc-generic
 boost|1.68.0|boost|thirdParties|http://repository.b-com.com/amc-generic
 spdlog|0.14.0|spdlog|thirdParties|http://repository.b-com.com/amc-generic

--- a/xpcf_SolARModuleOpenCV_registry.xml
+++ b/xpcf_SolARModuleOpenCV_registry.xml
@@ -121,6 +121,10 @@
                 <interface uuid="125f2007-1bf9-421d-9367-fbdc1210d006" name="IComponentIntrospect" description="IComponentIntrospect"/>
                 <interface uuid="0eadc8b7-1265-434c-a4c6-6da8a028e06e" name="IKeypointDetector" description="IKeypointDetector"/>
         </component>
+		 <component uuid="22c2ca9f-e43b-4a88-8337-4a166a789971" name="SolARKeypointDetectorRegionOpencv" description="SolARKeypointDetectorRegionOpencv">
+                <interface uuid="125f2007-1bf9-421d-9367-fbdc1210d006" name="IComponentIntrospect" description="IComponentIntrospect"/>
+                <interface uuid="64ccce51-b445-4ec5-a0fa-44156e8bc370" name="IKeypointDetectorRegion" description="IKeypointDetectorRegion"/>
+        </component>
         <component uuid="efcdb590-c570-11e7-abc4-cec278b6b50a" name="SolARMarker2DNaturalImageOpencv"  description="SolARMarker2DNaturalImageOpencv">
                 <interface uuid="125f2007-1bf9-421d-9367-fbdc1210d006" name="IComponentIntrospect" description="IComponentIntrospect"/>
                 <interface uuid="3c9cee8a-e9ca-4c16-851a-669a94c2a68d" name="IMarker" description="IMarker"/>
@@ -136,6 +140,14 @@
         <component uuid="9c960f2a-cd6e-11e7-abc4-cec278b6b50a" name="SolARPerspectiveControllerOpencv" description="SolARPerspectiveControllerOpencv">
                 <interface uuid="125f2007-1bf9-421d-9367-fbdc1210d006" name="IComponentIntrospect" description="IComponentIntrospect"/>
                 <interface uuid="4a7d5c34-cd6e-11e7-abc4-cec278b6b50a" name="IPerspectiveController" description="IPerspectiveController"/>
+        </component>
+		<component uuid="741fc298-0149-4322-a7a9-ccb971e857ba" name="SolARProjectOpencv" description="SolARProjectOpencv">
+                <interface uuid="125f2007-1bf9-421d-9367-fbdc1210d006" name="IComponentIntrospect" description="IComponentIntrospect"/>
+                <interface uuid="b485f37d-a8ea-49f6-b361-f2b30777d9ba" name="IProject" description="IProject"/>
+        </component>
+		<component uuid="9938354d-6476-437e-8325-97e82666a46e" name="SolARUnprojectPlanarPointsOpencv" description="SolARUnprojectPlanarPointsOpencv">
+                <interface uuid="125f2007-1bf9-421d-9367-fbdc1210d006" name="IComponentIntrospect" description="IComponentIntrospect"/>
+                <interface uuid="21113a74-de60-4a3c-8b65-f3112beb3dc6" name="IUnproject" description="IUnproject"/>
         </component>
 		<component uuid="9fbadf80-251f-4160-94f8-a64dc3d40a2f" name="SolARPoseEstimationPlanarPointsOpencv" description="Estimates the camera pose from 2D-3D planar points correspodances">
                 <interface uuid="125f2007-1bf9-421d-9367-fbdc1210d006" name="IComponentIntrospect" description="IComponentIntrospect"/>

--- a/xpcf_SolARModuleOpenCV_registry.xml
+++ b/xpcf_SolARModuleOpenCV_registry.xml
@@ -57,6 +57,10 @@
                 <interface uuid="125f2007-1bf9-421d-9367-fbdc1210d006" name="IComponentIntrospect" description="IComponentIntrospect"/>
                 <interface uuid="2e2bde18-ce39-11e7-abc4-cec278b6b50a" name="IDescriptorsExtractor" description="IDescriptorsExtractorSBPattern"/>
         </component>
+		<component uuid="b513e9ff-d2e7-4dcf-9a29-4ed95c512158" name="SolAROpticalFlowPyrLKOpencv" description="SolAROpticalFlowPyrLKOpencv">
+                <interface uuid="125f2007-1bf9-421d-9367-fbdc1210d006" name="IComponentIntrospect" description="IComponentIntrospect"/>
+                <interface uuid="3c74cd7f-950c-43ee-8886-9f4ddf763c27" name="IOpticalFlowEstimator" description="IDescriptorMatcher"/>
+        </component>
 		 <component uuid="31188e79-6bd5-43df-9633-6d6c5d7afb5c" name="SolARFundamentalMatrixDecompisitionValidationOpencv" description="SolARFundamentalMatrixDecompisitionValidationOpencv">
                 <interface uuid="125f2007-1bf9-421d-9367-fbdc1210d006" name="IComponentIntrospect" description="IComponentIntrospect"/>
                 <interface uuid="0f715b50-e0e5-4508-aaf0-cb252ea59ad4" name="IFundamentalMatrixDecompositionValidation" description="IFundamentalMatrixDecompositionValidation"/>

--- a/xpcf_SolARModuleOpenCV_registry.xml
+++ b/xpcf_SolARModuleOpenCV_registry.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <xpcf-registry>
-    <module uuid="15e1990b-86b2-445c-8194-0cbe80ede970" name="SolARModuleOpenCV" description="SolARModuleOpenCV" path="$BCOMDEVROOT/bcomBuild/SolARModuleOpenCV/0.5.0/lib/x86_64/shared">
+    <module uuid="15e1990b-86b2-445c-8194-0cbe80ede970" name="SolARModuleOpenCV" description="SolARModuleOpenCV" path="$BCOMDEVROOT/bcomBuild/SolARModuleOpenCV/0.5.2/lib/x86_64/shared">
         <component uuid="cedd8c47-e7b0-47bf-abb1-7fb54d198117" name="SolAR2D3DCorrespondencesFinderOpencv" description="SolAR2D3DCorrespondencesFinderOpencv">
                 <interface uuid="125f2007-1bf9-421d-9367-fbdc1210d006" name="IComponentIntrospect" description="IComponentIntrospect"/>
                 <interface uuid="0404e8b9-b824-4852-a34d-6eafa7563918" name="I2D3DCorrespondencesFinder" description="I2D3DCorrespondencesFinder"/>

--- a/xpcf_SolARModuleOpenCV_registry.xml
+++ b/xpcf_SolARModuleOpenCV_registry.xml
@@ -137,6 +137,10 @@
                 <interface uuid="125f2007-1bf9-421d-9367-fbdc1210d006" name="IComponentIntrospect" description="IComponentIntrospect"/>
                 <interface uuid="4a7d5c34-cd6e-11e7-abc4-cec278b6b50a" name="IPerspectiveController" description="IPerspectiveController"/>
         </component>
+		<component uuid="9fbadf80-251f-4160-94f8-a64dc3d40a2f" name="SolARPoseEstimationPlanarPointsOpencv" description="Estimates the camera pose from 2D-3D planar points correspodances">
+                <interface uuid="125f2007-1bf9-421d-9367-fbdc1210d006" name="IComponentIntrospect" description="IComponentIntrospect"/>
+                <interface uuid="8dd889c5-e8e6-4b3b-92e4-34cf7442f272" name="I3DTransformSACFinderFrom2D3D" description="I3DTransformSACFinderFrom2D3D"/>
+        </component>
         <component uuid="a38edf79-f0dc-45ca-92fc-2b336fceedf9" name="SolARPoseEstimationPnpEPFL" description="SolARPoseEstimationPnpEPFL">
                 <interface uuid="125f2007-1bf9-421d-9367-fbdc1210d006" name="IComponentIntrospect" description="IComponentIntrospect"/>
                 <interface uuid="77281cda-47c2-4bb7-bde6-5b0d02e75dae" name="I3DTransformFinderFrom2D3D" description="I3DTransformFinderFrom2D3D"/>
@@ -144,6 +148,10 @@
         <component uuid="0753ade1-7932-4e29-a71c-66155e309a53" name="SolARPoseEstimationPnpOpencv" description="SolARPoseEstimationPnpOpencv">
                 <interface uuid="125f2007-1bf9-421d-9367-fbdc1210d006" name="IComponentIntrospect" description="IComponentIntrospect"/>
                 <interface uuid="77281cda-47c2-4bb7-bde6-5b0d02e75dae" name="I3DTransformFinderFrom2D3D" description="I3DTransformFinderFrom2D3D"/>
+        </component>
+		 <component uuid="4d369049-809c-4e99-9994-5e8167bab808" name="SolARPoseEstimationSACPnpOpencv" description="SolARPoseEstimationSACPnpOpencv">
+                <interface uuid="125f2007-1bf9-421d-9367-fbdc1210d006" name="IComponentIntrospect" description="IComponentIntrospect"/>
+                <interface uuid="8dd889c5-e8e6-4b3b-92e4-34cf7442f272" name="I3DTransformSACFinderFrom2D3D" description="I3DTransformSACFinderFrom2D3D"/>
         </component>
 		<component uuid="52babb5e-9d33-11e8-98d0-529269fb1459" name="SolARPoseFinderFrom2D2DOpencv" description="SolARPoseFinderFrom2D2DOpencv">
                 <interface uuid="125f2007-1bf9-421d-9367-fbdc1210d006" name="IComponentIntrospect" description="IComponentIntrospect"/>


### PR DESCRIPTION
Add components for optical flow (SolAROpticalFlowPyrLK), for keypoint detection in a given region (SolARKeypointDetectorRegionOpencv), for 3D points projection (SolARProjectOpencv), for 2D points unprojection (SolARUnporjectPlanarPointsOpencv), and for Pose estimation adapted to planar points (SolARPoseEstimationPlanarPoints based on a homography estimation).
Update KeypointDetector to add opencv feature to track mode.
Update 2DOverlay component to display a single contour.
Update Marker2DSquared to get corner in world and image space.
SolARModuleOpencv moves to version 0.5.2