### PR TITLE
Better error handling when setting resolution of camera

### DIFF
--- a/src/SolARCameraOpencv.cpp
+++ b/src/SolARCameraOpencv.cpp
@@ -68,7 +68,7 @@ namespace OPENCV {
                 auto setResolution = [&]
                                      (cv::VideoCaptureProperties dimensionProp,
                                       uint32_t value,
-                                      std::string dimensionName)
+                                      const std::string& dimensionName)
                 {
                   bool setResDimOk = m_capture.set(dimensionProp, value);
 

--- a/src/SolARCameraOpencv.cpp
+++ b/src/SolARCameraOpencv.cpp
@@ -63,8 +63,33 @@ namespace OPENCV {
             LOG_INFO("Camera using {}  *  {} resolution", m_parameters.resolution.width ,m_parameters.resolution.height)
             if (m_is_resolution_set)
             {
-                m_capture.set(cv::CAP_PROP_FRAME_WIDTH, m_parameters.resolution.width );
-                m_capture.set(cv::CAP_PROP_FRAME_HEIGHT, m_parameters.resolution.height );
+                bool setResolutionFailed = false;
+
+                auto setResolution = [&]
+                                     (cv::VideoCaptureProperties dimensionProp,
+                                      uint32_t value,
+                                      std::string dimensionName)
+                {
+                  bool setResDimOk = m_capture.set(dimensionProp, value);
+
+                  if (!setResDimOk || m_capture.get(dimensionProp) != value)
+                  {
+                    setResolutionFailed = true;
+                    LOG_ERROR("Cannot set camera {} to {}", dimensionName, value);
+                    if (!setResDimOk)
+                    {
+                      LOG_WARNING( "Note: cv::VideoCapture::set() returned 'true'");
+                    }
+                  }
+                };
+
+                setResolution(cv::CAP_PROP_FRAME_WIDTH, m_parameters.resolution.width, "width");
+                setResolution(cv::CAP_PROP_FRAME_HEIGHT, m_parameters.resolution.height, "height");
+
+                if ( setResolutionFailed )
+                {
+                  return FrameworkReturnCode::_ERROR_;
+                }
             }
             else {
                 // set default resolution : get camera resolution ? or force camera resolution from default resolution values ?

--- a/src/SolARImagesAsCameraOpencv.cpp
+++ b/src/SolARImagesAsCameraOpencv.cpp
@@ -43,6 +43,11 @@ namespace OPENCV {
         if(!cvFrame.data)
             return FrameworkReturnCode::_ERROR_LOAD_IMAGE;
 
+        unsigned int w=cvFrame.cols;
+        unsigned int h=cvFrame.rows;
+        if(w!=m_parameters.resolution.width || h!=m_parameters.resolution.height)
+            cv::resize(cvFrame, cvFrame, cv::Size((int)m_parameters.resolution.width,(int)m_parameters.resolution.height), 0, 0);
+
         return SolAROpenCVHelper::convertToSolar(cvFrame,img);
     }
 
@@ -58,8 +63,28 @@ namespace OPENCV {
         {
             if (m_is_resolution_set)
             {
-                m_capture.set(cv::CAP_PROP_FRAME_WIDTH, m_parameters.resolution.width );
-                m_capture.set(cv::CAP_PROP_FRAME_HEIGHT, m_parameters.resolution.height );
+                LOG_INFO("Camera using {}  *  {} resolution", m_parameters.resolution.width ,m_parameters.resolution.height)
+
+                auto setResolution = [&]
+                                     (cv::VideoCaptureProperties dimensionProp,
+                                      uint32_t value,
+                                      std::string dimensionName)
+                {
+                  bool setResDimOk = m_capture.set(dimensionProp, value);
+
+                  if (!setResDimOk || m_capture.get(dimensionProp) != value)
+                  {
+                    LOG_WARNING("Cannot set camera {} to {}. Will fallback to cv::resize() each frame", dimensionName, value);
+                    if (!setResDimOk)
+                    {
+                      LOG_WARNING( "Note: cv::VideoCapture::set() returned 'true'");
+                    }
+                  }
+                };
+
+                setResolution(cv::CAP_PROP_FRAME_WIDTH, m_parameters.resolution.width, "width");
+                setResolution(cv::CAP_PROP_FRAME_HEIGHT, m_parameters.resolution.height, "height");
+
             }
             return FrameworkReturnCode::_SUCCESS;
         }

--- a/src/SolARImagesAsCameraOpencv.cpp
+++ b/src/SolARImagesAsCameraOpencv.cpp
@@ -68,7 +68,7 @@ namespace OPENCV {
                 auto setResolution = [&]
                                      (cv::VideoCaptureProperties dimensionProp,
                                       uint32_t value,
-                                      std::string dimensionName)
+                                      const std::string& dimensionName)
                 {
                   bool setResDimOk = m_capture.set(dimensionProp, value);
 

--- a/src/SolARVideoAsCameraOpencv.cpp
+++ b/src/SolARVideoAsCameraOpencv.cpp
@@ -66,8 +66,27 @@ using namespace datastructure;
         {
             if (m_is_resolution_set)
             {
-                m_capture.set(cv::CAP_PROP_FRAME_WIDTH, m_parameters.resolution.width );
-                m_capture.set(cv::CAP_PROP_FRAME_HEIGHT, m_parameters.resolution.height );
+                LOG_INFO("Camera using {}  *  {} resolution", m_parameters.resolution.width ,m_parameters.resolution.height)
+
+                auto setResolution = [&]
+                                     (cv::VideoCaptureProperties dimensionProp,
+                                      uint32_t value,
+                                      std::string dimensionName)
+                {
+                  bool setResDimOk = m_capture.set(dimensionProp, value);
+
+                  if (!setResDimOk || m_capture.get(dimensionProp) != value)
+                  {
+                    LOG_WARNING("Cannot set camera {} to {}. Will fallback to cv::resize() each frame", dimensionName, value);
+                    if (!setResDimOk)
+                    {
+                      LOG_WARNING( "Note: cv::VideoCapture::set() returned 'true'");
+                    }
+                  }
+                };
+
+                setResolution(cv::CAP_PROP_FRAME_WIDTH, m_parameters.resolution.width, "width");
+                setResolution(cv::CAP_PROP_FRAME_HEIGHT, m_parameters.resolution.height, "height");
             }
             return FrameworkReturnCode::_SUCCESS;
         }

--- a/src/SolARVideoAsCameraOpencv.cpp
+++ b/src/SolARVideoAsCameraOpencv.cpp
@@ -71,7 +71,7 @@ using namespace datastructure;
                 auto setResolution = [&]
                                      (cv::VideoCaptureProperties dimensionProp,
                                       uint32_t value,
-                                      std::string dimensionName)
+                                      const std::string& dimensionName)
                 {
                   bool setResDimOk = m_capture.set(dimensionProp, value);
 


### PR DESCRIPTION
This patch improves error handling regarding the setting of resolution with OpenCV camera implementation (webcam, video or image sequence).


**Webcam:**
_No errors (640x480)_
```
[2021-07-16 15:47:17:936121] [info] [31292] [SolAR::MODULES::OPENCV::SolARCameraOpencv::start():62] Camera with id 0 has started
[2021-07-16 15:47:17:936184] [info] [31292] [SolAR::MODULES::OPENCV::SolARCameraOpencv::start():63] Camera using 640  *  480 resolution

```
_Error for some resolutions (1920x1088)_
```
[2021-07-16 15:49:12:733358] [info] [24952] [SolAR::MODULES::OPENCV::SolARCameraOpencv::start():63] Camera using 1920  *  1088 resolution
[2021-07-16 15:49:13:680778] [error] [24952] [SolAR::MODULES::OPENCV::SolARCameraOpencv::start::<lambda_f3faf3308cf3a28ac100183daee8636d>::operator ()():78] Cannot set camera width to 1920
[2021-07-16 15:49:14:637358] [error] [24952] [SolAR::MODULES::OPENCV::SolARCameraOpencv::start::<lambda_f3faf3308cf3a28ac100183daee8636d>::operator ()():78] Cannot set camera height to 1088
[2021-07-16 15:49:14:637421] [error] [24952] [SolAR::PIPELINES::PipelineFiducialMarker::start():218] Camera cannot start
```
New code handles the error, thus avoiding ugly crashes.


**ImagesAsCamera**
Return status of capure::set() is misleading: it's true whereas resolution has not been changed.
-> can be removed in favor of cv::resize() of each frame() ?

```
[2021-07-16 15:45:28:762602] [info] [30156] [SolAR::MODULES::OPENCV::SolARImagesAsCameraOpencv::start():66] Camera using 640  *  480 resolution
[ INFO:0] global C:\.conan\a612bf\1\source_subfolder\modules\videoio\src\cap_images.cpp (199) cv::CvCapture_Images::setProperty CAP_IMAGES warning: %s (%s:%d)unknown/unhandled property
[2021-07-16 15:45:28:763029] [warning] [30156] [SolAR::MODULES::OPENCV::SolARImagesAsCameraOpencv::start::<lambda_9e318d050bd28b5dacf7d828d335ac94>::operator ()():77] Cannot set camera width to 640. Will fallback to cv::resize() each frame
[2021-07-16 15:45:28:763280] [warning] [30156] [SolAR::MODULES::OPENCV::SolARImagesAsCameraOpencv::start::<lambda_9e318d050bd28b5dacf7d828d335ac94>::operator ()():80] Note: cv::VideoCapture::set() returned 'true'
[ INFO:0] global C:\.conan\a612bf\1\source_subfolder\modules\videoio\src\cap_images.cpp (199) cv::CvCapture_Images::setProperty CAP_IMAGES warning: %s (%s:%d)unknown/unhandled property
[2021-07-16 15:45:28:763833] [warning] [30156] [SolAR::MODULES::OPENCV::SolARImagesAsCameraOpencv::start::<lambda_9e318d050bd28b5dacf7d828d335ac94>::operator ()():77] Cannot set camera height to 480. Will fallback to cv::resize() each frame
[2021-07-16 15:45:28:764017] [warning] [30156] [SolAR::MODULES::OPENCV::SolARImagesAsCameraOpencv::start::<lambda_9e318d050bd28b5dacf7d828d335ac94>::operator ()():80] Note: cv::VideoCapture::set() returned 'true'

```
**Video As Camera**
capture::set does not work -> can be removed in favor of cv::resize() of each frame() ?

```
[2021-07-16 15:44:11:810995] [info] [26532] [SolAR::MODULES::OPENCV::SolARVideoAsCameraOpencv::start():69] Camera using 640  *  480 resolution
[2021-07-16 15:44:11:813414] [warning] [26532] [SolAR::MODULES::OPENCV::SolARVideoAsCameraOpencv::start::<lambda_9953ab824309641249dcbfb56171e82e>::operator ()():80] Cannot set camera width to 640. Will fallback to cv::resize() each frame
[2021-07-16 15:44:11:815615] [warning] [26532] [SolAR::MODULES::OPENCV::SolARVideoAsCameraOpencv::start::<lambda_9953ab824309641249dcbfb56171e82e>::operator ()():80] Cannot set camera height to 480. Will fallback to cv::resize() each frame
```
